### PR TITLE
FDT Memory Detection + Boot Allocator Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -504,4 +504,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Device Tree Files
+*.dtb
+*.dts
+
 # End of https://www.toptal.com/developers/gitignore/api/c,c++,python,emacs,nvim,visualstudiocode,clion,linux,macos,windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Device Tree Files
+*.dtb
+*.dts
+
 # Configuration
 .config*
 
@@ -503,9 +507,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
-
-# Device Tree Files
-*.dtb
-*.dts
 
 # End of https://www.toptal.com/developers/gitignore/api/c,c++,python,emacs,nvim,visualstudiocode,clion,linux,macos,windows

--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <kernel/early_output.h>
 #include <kernel/of/fdt.h>
+#include <kernel/of/fdt_mem.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -125,6 +126,9 @@ kmain(uint64_t hartid, struct fdt* fdt)
         }
 #undef NUM_PARENTS
     }
+
+    // Initialize the boot memory allocator using the FDT
+    fdt_boot_mem_init(fdt);
 
     // Call global ctors
     preinit();

--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <kernel/early_output.h>
+#include <kernel/mem/boot.h>
 #include <kernel/of/fdt.h>
 #include <kernel/of/fdt_mem.h>
-#include <kernel/mem/boot.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -115,7 +115,7 @@ kmain(uint64_t hartid, struct fdt* fdt)
     boot_mem_dump();
 
     // Allocate a page aligned to 16 bytes
-    void *alloc = boot_alloc(0x1000, 4);
+    void* alloc = boot_alloc(0x1000, 4);
     printk("alloc = %p\n", alloc);
 
     boot_mem_dump();

--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -1,7 +1,7 @@
 #include "kernel/early_output.h"
+#include "kernel/mem/boot.h"
 #include "kernel/of/fdt.h"
 #include "kernel/of/fdt_mem.h"
-#include "kernel/mem/boot.h"
 
 #include "drivers/syscon.h"
 
@@ -131,7 +131,7 @@ kmain(uint64_t hartid, struct fdt* fdt)
         printk("Error setting up syscon\n");
         syscon_ok = false;
     }
-    
+
     // Call global ctors
     preinit();
     init();

--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -2,6 +2,7 @@
 #include <kernel/early_output.h>
 #include <kernel/of/fdt.h>
 #include <kernel/of/fdt_mem.h>
+#include <kernel/mem/boot.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -105,30 +106,19 @@ kmain(uint64_t hartid, struct fdt* fdt)
 
     fdt_dump(fdt);
 
-    printk("FOODBADD = %p\n", (void*)0xf00dbadd);
-
-    // Testing FDT functions
-    struct fdt_node* node = fdt_find_node_by_device_type(fdt, NULL, "memory");
-    if (node == NULL) {
-        printk("Could not find node!\n");
-    }
-    else {
-        printk("Found node! (%s)\n", fdt_node_name(node));
-
-#define NUM_PARENTS 3
-        struct fdt_node* parents[NUM_PARENTS];
-        size_t parents_read = fdt_node_get_parents(fdt, node, parents, NUM_PARENTS);
-        assert(parents_read <= NUM_PARENTS);
-
-        printk("Parents of (%s)\n", fdt_node_name(node));
-        for (size_t i = 0; i < parents_read; i++) {
-            printk("Parent[%p] = %s\n", (void*)(uintptr_t)i, fdt_node_name(parents[i]));
-        }
-#undef NUM_PARENTS
-    }
-
     // Initialize the boot memory allocator using the FDT
     fdt_boot_mem_init(fdt);
+
+    // Testing the boot memory allocator
+
+    // Dump the mem map
+    boot_mem_dump();
+
+    // Allocate a page aligned to 16 bytes
+    void *alloc = boot_alloc(0x1000, 4);
+    printk("alloc = %p\n", alloc);
+
+    boot_mem_dump();
 
     // Call global ctors
     preinit();

--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -108,7 +108,7 @@ kmain(uint64_t hartid, struct fdt* fdt)
     printk("FOODBADD = %p\n", (void*)0xf00dbadd);
 
     // Testing FDT functions
-    struct fdt_node* node = fdt_find_node_by_unit_name(fdt, NULL, "cpu-map");
+    struct fdt_node* node = fdt_find_node_by_device_type(fdt, NULL, "memory");
     if (node == NULL) {
         printk("Could not find node!\n");
     }

--- a/include/kernel/attribute.h
+++ b/include/kernel/attribute.h
@@ -14,9 +14,9 @@
 #endif
 
 #ifdef __GNUC__
-#define KERNEL_ALIGNED(b) __attribute__((aligned (b)))
-#else 
-#error "Alignment attribute is not supported!"
+#  define KERNEL_ALIGNED(b) __attribute__((aligned(b)))
+#else
+#  error "Alignment attribute is not supported!"
 #endif
 
 #endif

--- a/include/kernel/attribute.h
+++ b/include/kernel/attribute.h
@@ -2,15 +2,15 @@
 #define __KERNEL__ATTRIBUTE_H__
 
 #ifdef __GNUC__
-#define KERNEL_PACKED __attribute__((packed))
+#  define KERNEL_PACKED __attribute__((packed))
 #else
-#error "Packed structs are not supported!"
+#  error "Packed structs are not supported!"
 #endif
 
 #ifdef __GNUC__
-#define KERNEL_SECTION(sec_str) __attribute__((section(sec_str)))
+#  define KERNEL_SECTION(sec_str) __attribute__((section(sec_str)))
 #else
-#error "Section attributes are not supported!"
+#  error "Section attributes are not supported!"
 #endif
 
 #endif

--- a/include/kernel/attribute.h
+++ b/include/kernel/attribute.h
@@ -1,0 +1,16 @@
+#ifndef __KERNEL__ATTRIBUTE_H__
+#define __KERNEL__ATTRIBUTE_H__
+
+#ifdef __GNUC__
+#define KERNEL_PACKED __attribute__((packed))
+#else
+#error "Packed structs are not supported!"
+#endif
+
+#ifdef __GNUC__
+#define KERNEL_SECTION(sec_str) __attribute__((section(sec_str)))
+#else
+#error "Section attributes are not supported!"
+#endif
+
+#endif

--- a/include/kernel/attribute.h
+++ b/include/kernel/attribute.h
@@ -13,4 +13,10 @@
 #  error "Section attributes are not supported!"
 #endif
 
+#ifdef __GNUC__
+#define KERNEL_ALIGNED(b) __attribute__((aligned (b)))
+#else 
+#error "Alignment attribute is not supported!"
+#endif
+
 #endif

--- a/include/kernel/error.h
+++ b/include/kernel/error.h
@@ -25,6 +25,9 @@ enum kerror {
     KERR_BUSY, // Less so an error, but an opportunity to do other work and try again
                // later
 
+    KERR_UNIMPL, // This feature is not implemented 
+                 // (call did nothing and should have zero side effects)
+
     KERR_UNKNOWN, // Unknown error (catch all DO NOT USE WITHOUT GOOD REASON)
 };
 typedef enum kerror kerror_t;

--- a/include/kernel/error.h
+++ b/include/kernel/error.h
@@ -25,7 +25,7 @@ enum kerror {
     KERR_BUSY, // Less so an error, but an opportunity to do other work and try again
                // later
 
-    KERR_UNIMPL, // This feature is not implemented 
+    KERR_UNIMPL, // This feature is not implemented
                  // (call did nothing and should have zero side effects)
 
     KERR_UNKNOWN, // Unknown error (catch all DO NOT USE WITHOUT GOOD REASON)

--- a/include/kernel/mem/boot.h
+++ b/include/kernel/mem/boot.h
@@ -1,7 +1,7 @@
-#ifndef __KERNEL_MEM_BOOT_H__
-#define __KERNEL_MEM_BOOT_H__
+#ifndef __KERNEL__MEM_BOOT_H__
+#define __KERNEL__MEM_BOOT_H__
 
-#include <kernel/error.h>
+#include "kernel/error.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/include/kernel/mem/boot.h
+++ b/include/kernel/mem/boot.h
@@ -2,22 +2,32 @@
 #define __KERNEL_MEM_BOOT_H__
 
 #include<stdint.h>
+#include<stddef.h>
 #include<kernel/error.h>
 
-// Doubly-linked list of free regions in physical memory
-struct boot_free_region {
-  struct boot_free_region *next;
-  struct boot_free_region *prev;
-  size_t size;
-};
+/*
+ * ---Boot Allocator Front End---
+ *
+ * These functions can have multiple implementations selected by
+ * which file(s) are compiled and linked in from the folder "kernel/mem/boot/"
+ *
+ * The memory detection system at boot should use "boot_free" to add memory
+ * to the system and needs to be careful never to free 
+ * the same address more than once.
+ * (Even if some backends such as bitmaps could support that)
+ *
+ * NOTE:
+ *       boot_alloc should be used sparingly and for permanent allocations.
+ *       boot_free is meant more for giving more memory to the boot allocator
+ *       than it is for freeing allocations made by boot_alloc (but theoretically could be used for that purpose).
+*
+ */
 
 /*
  * Try to allocate "size" bytes with alignment "2**alignment",
- * shrinking the boot_free_list.
  *
  * Returns a pointer to the region or NULL if the allocation failed.
  *
- * Invalidates all struct boot_free_region pointers
  */
 void * boot_alloc(size_t size, unsigned int alignment);
 
@@ -26,25 +36,12 @@ void * boot_alloc(size_t size, unsigned int alignment);
  *
  * Returns:
  *     KERR_SUCCESS on success
- *     KERR_EXIST if the region overlaps an existing region
- *     KERR_EMPTY if the region is too small (size < sizeof(struct boot_free_region))
+ *     KERR_EXIST - if a double free is detected
+ *     KERR_EMPTY - if the region is too small to free
+ *     KERR_FULL - if the region is too large to free
+ *     KERR_UNKNOWN - any other error (we don't know what the backend is so there could be weird reasons we can anticipate)
  *
- * NOTE: boot_free is not perfect,
- *       boot_alloc should be used sparingly and for permenant allocations
- *       boot_free is meant more for giving more memory to the boot allocator
- *       than it is for freeing allocations made by boot_alloc.
  */
 kerror_t boot_free(void *start, size_t size);
-
-/*
- * Get the first (lowest address) region in the free list
- */
-struct boot_free_region * boot_free_list_begin(void);
-
-/*
- * Get the next region (next higher address) in the free list (or NULL)
- */
-struct boot_free_region * boot_free_list_next(struct boot_free_region *region);
-
 
 #endif

--- a/include/kernel/mem/boot.h
+++ b/include/kernel/mem/boot.h
@@ -1,0 +1,50 @@
+#ifndef __KERNEL_MEM_BOOT_H__
+#define __KERNEL_MEM_BOOT_H__
+
+#include<stdint.h>
+#include<kernel/error.h>
+
+// Doubly-linked list of free regions in physical memory
+struct boot_free_region {
+  struct boot_free_region *next;
+  struct boot_free_region *prev;
+  size_t size;
+};
+
+/*
+ * Try to allocate "size" bytes with alignment "2**alignment",
+ * shrinking the boot_free_list.
+ *
+ * Returns a pointer to the region or NULL if the allocation failed.
+ *
+ * Invalidates all struct boot_free_region pointers
+ */
+void * boot_alloc(size_t size, unsigned int alignment);
+
+/*
+ * Tries to add the memory at physical address "start" of length "size" to the free list
+ *
+ * Returns:
+ *     KERR_SUCCESS on success
+ *     KERR_EXIST if the region overlaps an existing region
+ *     KERR_EMPTY if the region is too small (size < sizeof(struct boot_free_region))
+ *
+ * NOTE: boot_free is not perfect,
+ *       boot_alloc should be used sparingly and for permenant allocations
+ *       boot_free is meant more for giving more memory to the boot allocator
+ *       than it is for freeing allocations made by boot_alloc.
+ */
+kerror_t boot_free(void *start, size_t size);
+
+/*
+ * Get the first (lowest address) region in the free list
+ */
+struct boot_free_region * boot_free_list_begin(void);
+
+/*
+ * Get the next region (next higher address) in the free list (or NULL)
+ */
+struct boot_free_region * boot_free_list_next(struct boot_free_region *region);
+
+
+#endif

--- a/include/kernel/mem/boot.h
+++ b/include/kernel/mem/boot.h
@@ -2,6 +2,7 @@
 #define __KERNEL__MEM_BOOT_H__
 
 #include "kernel/error.h"
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/include/kernel/mem/boot.h
+++ b/include/kernel/mem/boot.h
@@ -21,6 +21,8 @@
  *       boot_free is meant more for giving more memory to the boot allocator
  *       than it is for freeing allocations made by boot_alloc (but theoretically could be used for that purpose).
 *
+*        All of these functions are also full of race conditions, so once 
+*        multi-threading/processing is up and running these cannot be used.
  */
 
 /*
@@ -43,5 +45,15 @@ void * boot_alloc(size_t size, unsigned int alignment);
  *
  */
 kerror_t boot_free(void *start, size_t size);
+
+/*
+ * Dumps the current memory map to printk in a backend defined (HUMAN READABLE) format or does nothing
+ *
+ * Returns:
+ *     KERR_SUCCESS on success
+ *     KERR_UNIMPL - if the backend didn't implement this function (should have no side effects)
+ *                   (it's not really essential, but is very nice for debugging)
+ */
+kerror_t boot_mem_dump(void);
 
 #endif

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -11,7 +11,7 @@ extern "C" {
 // Device Tree Version 17 Specification
 // https://devicetree-specification.readthedocs.io/en/stable/flattened-format.html#figure-device-tree-structure
 
-// Bad debugging system (should integrate into Kconfig or delete entirely later)
+// TODO: Bad debugging system (should integrate into Kconfig or delete entirely later)
 #define FDT_DEBUG_DEBUG_NAMELESS_NODES
 //
 

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -241,6 +241,20 @@ size_t fdt_prop_num_cells(struct fdt_prop *prop);
  */
 uint32_t fdt_prop_get_cell(struct fdt_prop *prop, size_t index);
 
+/*
+ * Returns the number of register blocks in the "reg" property of this node (0 if there is no reg property)
+ */
+size_t fdt_node_num_register_blocks(struct fdt *fdt, struct fdt_node *node);
+
+
+/*
+ * Reads the "reg" property using "#address-cells" and "#size-cells",
+ * Set's "address" and "size" accordingly
+ *
+ * If an error occurs, "size" is set to zero.
+ */
+void fdt_node_get_register_block(struct fdt *fdt, struct fdt_node *node, size_t index, void ** address, size_t * size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -14,7 +14,8 @@ extern "C" {
 
 #define FDT_COMPAT_VERSION 17
 
-struct fdt {
+struct fdt 
+{
     uint32_t magic;
     uint32_t totalsize;
     uint32_t off_dt_struct;
@@ -25,24 +26,27 @@ struct fdt {
     uint32_t boot_cpuid_phys;
     uint32_t size_dt_strings;
     uint32_t size_dt_struct;
-};
+} __attribute__((packed));
 
-struct fdt_node {
+struct fdt_node 
+{
     uint32_t token;
     char unit_name[];
 };
 
-struct fdt_prop {
+struct fdt_prop 
+{
     uint32_t token;
     uint32_t len;
     uint32_t name_offset;
     uint8_t val[];
-};
+} __attribute__((packed));
 
-struct fdt_reserve_entry {
+struct fdt_reserve_entry 
+{
     uint64_t address;
     uint64_t size;
-};
+} __attribute__((packed));
 
 #define FDT_HEADER_MAGIC 0xd00dfeed
 

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -8,6 +8,10 @@
 extern "C" {
 #endif
 
+// Bad debugging system (should integrate into Kconfig or delete entirely later)
+#define FDT_DEBUG_DEBUG_NAMELESS_NODES
+//
+
 #define FDT_COMPAT_VERSION 17
 
 struct fdt {
@@ -71,6 +75,12 @@ enum fdt_error fdt_verify(struct fdt *fdt);
 size_t fdt_size(struct fdt *fdt);
 
 /*
+ * Get the maximum depth of this FDT
+ * where a "root" node is at depth 0 and subnodes increase the depth by 1
+ */
+int fdt_max_depth(struct fdt *fdt);
+
+/*
  * Get the first FDT reserve_entry (or NULL if there are none)
  */
 struct fdt_reserve_entry * fdt_reserve_entry_begin(struct fdt *fdt);
@@ -103,7 +113,7 @@ struct fdt_node * fdt_node_begin(struct fdt *fdt);
 /*
  * Returns the next node in the tree (or NULL) traversing the entire tree regardless of depth
  */
-struct fdt_node * fdt_next_node(struct fdt *fdt, struct fdt_node *node);
+struct fdt_node * fdt_next_node(struct fdt *fdt, struct fdt_node *node, int *depth);
 
 /*
  * Returns the first property in this node (or NULL if there are none)
@@ -124,6 +134,16 @@ struct fdt_node * fdt_node_subnode_begin(struct fdt *fdt, struct fdt_node *node)
  * Returns the next subnode after this one (or NULL)
  */
 struct fdt_node * fdt_node_next_subnode(struct fdt *fdt, struct fdt_node *subnode);
+
+/*
+ * Populates the provided array parents, of size parents_size,
+ * with the parent node(s) of "node".
+ *
+ * Returns the number of ancestors added to parents[]
+ *
+ * "parents" will go from closest ancestor to furthest as the index increases
+ */
+size_t fdt_node_get_parents(struct fdt *fdt, struct fdt_node *node, struct fdt_node * parents[], size_t parents_size);
 
 /*
  * Get the string at offset "offset" in the string block
@@ -158,6 +178,24 @@ struct fdt_prop * fdt_get_prop_by_name(struct fdt *fdt, struct fdt_node *node, s
  * or if "start" is NULL, the first node in the FDT (inclusive)
  */
 struct fdt_node * fdt_find_compatible_node(struct fdt *fdt, struct fdt_node *start, const char *compat);
+
+/*
+ * Find a node in the device tree with "device_type" equal to "type"
+ * The search will begin on node "start" (exclusive)
+ * or if "start" is NULL, the first node in the FDT (inclusive)
+ */
+struct fdt_node * fdt_find_node_by_device_type(struct fdt *fdt, struct fdt_node *start, const char *type);
+
+/*
+ * Find a node in the device tree with unit_name equal to "name"
+ * The search will begin on node "start" (exclusive)
+ * or if "start" is NULL, the first node in the FDT (inclusive)
+ *
+ * TODO: THIS IS NOT CORRECT YET
+ *       really to be useful, we should only compare "name" to the part of the string before "@",
+ *       which we currently don't do.
+ */
+struct fdt_node * fdt_find_node_by_unit_name(struct fdt *fdt, struct fdt_node *start, const char *name);
 
 /*
  * Returns true if "node" is compatible with "compat", else false

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -30,24 +30,24 @@ struct fdt {
     uint32_t boot_cpuid_phys;
     uint32_t size_dt_strings;
     uint32_t size_dt_struct;
-} KERNEL_PACKED;
+} KERNEL_PACKED KERNEL_ALIGNED(sizeof(void*));
 
 struct fdt_node {
     uint32_t token;
     char unit_name[];
-};
+} KERNEL_PACKED KERNEL_ALIGNED(4);
 
 struct fdt_prop {
     uint32_t token;
     uint32_t len;
     uint32_t name_offset;
     uint8_t val[];
-} KERNEL_PACKED;
+} KERNEL_PACKED KERNEL_ALIGNED(4);
 
 struct fdt_reserve_entry {
     uint64_t address;
     uint64_t size;
-} KERNEL_PACKED;
+} KERNEL_PACKED KERNEL_ALIGNED(sizeof(void*));
 
 #define FDT_HEADER_MAGIC 0xd00dfeed
 

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -14,8 +14,7 @@ extern "C" {
 
 #define FDT_COMPAT_VERSION 17
 
-struct fdt 
-{
+struct fdt {
     uint32_t magic;
     uint32_t totalsize;
     uint32_t off_dt_struct;
@@ -28,22 +27,19 @@ struct fdt
     uint32_t size_dt_struct;
 } __attribute__((packed));
 
-struct fdt_node 
-{
+struct fdt_node {
     uint32_t token;
     char unit_name[];
 };
 
-struct fdt_prop 
-{
+struct fdt_prop {
     uint32_t token;
     uint32_t len;
     uint32_t name_offset;
     uint8_t val[];
 } __attribute__((packed));
 
-struct fdt_reserve_entry 
-{
+struct fdt_reserve_entry {
     uint64_t address;
     uint64_t size;
 } __attribute__((packed));

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -212,6 +212,35 @@ struct fdt_node * fdt_find_node_by_unit_name(struct fdt *fdt, struct fdt_node *s
  */
 bool fdt_node_is_compatible(struct fdt *fdt, struct fdt_node *node, const char *compat); 
 
+/*
+ * Returns the closest definition of property "prop_name",
+ * first checking the node itself, and then going to it's parent, grandparent, etc.
+ *
+ * Returns NULL if none are found.
+ */
+struct fdt_prop * fdt_node_get_inherited_prop(struct fdt *fdt, struct fdt_node *node, const char *prop_name);
+
+/*
+ * Returns the #address-cells inherited property for this node
+ */
+uint32_t fdt_node_get_address_cells(struct fdt *fdt, struct fdt_node *node);
+
+/*
+ * Returns the #size-cells inherited property for this node
+ */
+uint32_t fdt_node_get_address_cells(struct fdt *fdt, struct fdt_node *node);
+
+/*
+ * Assumes this property contains an array of cells (u32's) and returns how many cells long it is
+ */
+size_t fdt_prop_num_cells(struct fdt_prop *prop);
+
+/*
+ * Assumes this property contains an array of cells (u32's) and returns the cell at index 
+ *.
+ */
+uint32_t fdt_prop_get_cell(struct fdt_prop *prop, size_t index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -91,6 +91,16 @@ struct fdt_reserve_entry * fdt_reserve_entry_begin(struct fdt *fdt);
 struct fdt_reserve_entry * fdt_next_reserve_entry(struct fdt *fdt, struct fdt_reserve_entry *entry);
 
 /*
+ * Get the base address of this reserve entry
+ */
+void * fdt_reserve_entry_address(struct fdt_reserve_entry *entry);
+
+/*
+ * Get the size in bytes of this reserve entry
+ */
+size_t fdt_reserve_entry_size(struct fdt_reserve_entry *entry);
+
+/*
  * Get the length of the value of this property in bytes
  */
 size_t fdt_prop_val_len(struct fdt_prop *prop);

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -35,6 +35,11 @@ struct fdt_prop {
     uint8_t val[];
 };
 
+struct fdt_reserve_entry {
+    uint64_t address;
+    uint64_t size;
+};
+
 #define FDT_HEADER_MAGIC 0xd00dfeed
 
 #define FDT_BEGIN_NODE 0x1
@@ -64,6 +69,16 @@ enum fdt_error fdt_verify(struct fdt *fdt);
  * Get the size of this FDT in bytes
  */
 size_t fdt_size(struct fdt *fdt);
+
+/*
+ * Get the first FDT reserve_entry (or NULL if there are none)
+ */
+struct fdt_reserve_entry * fdt_reserve_entry_begin(struct fdt *fdt);
+
+/*
+ * Returns the next reserve_entry in the FDT (or NULL)
+ */
+struct fdt_reserve_entry * fdt_next_reserve_entry(struct fdt *fdt, struct fdt_reserve_entry *entry);
 
 /*
  * Get the length of the value of this property in bytes

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "kernel/attribute.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -28,7 +30,7 @@ struct fdt {
     uint32_t boot_cpuid_phys;
     uint32_t size_dt_strings;
     uint32_t size_dt_struct;
-} __attribute__((packed));
+} KERNEL_PACKED;
 
 struct fdt_node {
     uint32_t token;
@@ -40,12 +42,12 @@ struct fdt_prop {
     uint32_t len;
     uint32_t name_offset;
     uint8_t val[];
-} __attribute__((packed));
+} KERNEL_PACKED;
 
 struct fdt_reserve_entry {
     uint64_t address;
     uint64_t size;
-} __attribute__((packed));
+} KERNEL_PACKED;
 
 #define FDT_HEADER_MAGIC 0xd00dfeed
 

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -1,10 +1,10 @@
 #ifndef __KERNEL_OF_FDT_H__
 #define __KERNEL_OF_FDT_H__
 
+#include "kernel/attribute.h"
+
 #include <stdint.h>
 #include <string.h>
-
-#include "kernel/attribute.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+// Device Tree Version 17 Specification
+// https://devicetree-specification.readthedocs.io/en/stable/flattened-format.html#figure-device-tree-structure
+
 // Bad debugging system (should integrate into Kconfig or delete entirely later)
 #define FDT_DEBUG_DEBUG_NAMELESS_NODES
 //

--- a/include/kernel/of/fdt_mem.h
+++ b/include/kernel/of/fdt_mem.h
@@ -2,11 +2,10 @@
 #define __KERNEL_FDT_MEM_H__
 
 #include<kernel/mem/boot.h>
+#include<kernel/error.h>
+#include<kernel/of/fdt.h>
 
 kerror_t
-fdt_boot_mem_init(struct fdt *fdt)
-{
-
-}
+fdt_boot_mem_init(struct fdt *fdt);
 
 #endif

--- a/include/kernel/of/fdt_mem.h
+++ b/include/kernel/of/fdt_mem.h
@@ -1,9 +1,9 @@
-#ifndef __KERNEL_FDT_MEM_H__
-#define __KERNEL_FDT_MEM_H__
+#ifndef __KERNEL__FDT_MEM_H__
+#define __KERNEL__FDT_MEM_H__
 
-#include <kernel/error.h>
-#include <kernel/mem/boot.h>
-#include <kernel/of/fdt.h>
+#include "kernel/error.h"
+#include "kernel/mem/boot.h"
+#include "kernel/of/fdt.h"
 
 kerror_t fdt_boot_mem_init(struct fdt* fdt);
 

--- a/include/kernel/of/fdt_mem.h
+++ b/include/kernel/of/fdt_mem.h
@@ -1,0 +1,12 @@
+#ifndef __KERNEL_FDT_MEM_H__
+#define __KERNEL_FDT_MEM_H__
+
+#include<kernel/mem/boot.h>
+
+kerror_t
+fdt_boot_mem_init(struct fdt *fdt)
+{
+
+}
+
+#endif

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -48,6 +48,7 @@ include(cmake/modules.cmake)
 
 add_root_dir("arch/${CONFIG_ARCH_DIR}")  # architecture directory
 add_subdirectory("of") # Open Firmware Support
+add_subdirectory("mem") # Memory Framework / Memory Allocators 
 # add_root_dir("drivers")
 
 # ----- Add target -----

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -24,6 +24,9 @@ set(KERN_CXX_FLAGS "-include ${AUTOCONF_HEADER}")
 set(CMAKE_C_FLAGS "${KERN_C_FLAGS} ${ARCH_KERN_C_FLAGS} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${KERN_CXX_FLAGS} ${ARCH_KERN_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
+# Run checks
+include(cmake/checks.cmake)
+
 # ----- Sources -----
 
 # Get list of sources

--- a/kernel/cmake/checks.cmake
+++ b/kernel/cmake/checks.cmake
@@ -1,0 +1,16 @@
+include(CheckCSourceCompiles)
+
+# ----- VLA Support -----
+check_c_source_compiles(
+    "
+    int foo(int n) {
+        volatile int arr[n + 5];
+        return arr[n];
+    }
+    "
+    HAVE_VLA
+)
+
+if(NOT HAVE_VLA)
+    message(FATAL_ERROR "VLAs are not supported, cannot continue with build.")
+endif()

--- a/kernel/mem/CMakeLists.txt
+++ b/kernel/mem/CMakeLists.txt
@@ -1,14 +1,15 @@
 set(
   KERNEL_MEM_SOURCES
   # Runtime
-  boot.c
 )
+
+add_subdirectory("boot") # Boot Memory Allocator Implementations
 
 list(APPEND KERNEL_MEM_INCLUDES include)
 
 add_kernel_module(
   CORE # core module
   NAME "memory"
-  SOURCES ${KERNEL_OF_SOURCES}
-  INCLUDE_DIRS ${KERNEL_OF_INCLUDES}
+  SOURCES ${KERNEL_MEM_SOURCES}
+  INCLUDE_DIRS ${KERNEL_MEM_INCLUDES}
 )

--- a/kernel/mem/CMakeLists.txt
+++ b/kernel/mem/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(
+  KERNEL_MEM_SOURCES
+  # Runtime
+  boot.c
+)
+
+list(APPEND KERNEL_MEM_INCLUDES include)
+
+add_kernel_module(
+  CORE # core module
+  NAME "memory"
+  SOURCES ${KERNEL_OF_SOURCES}
+  INCLUDE_DIRS ${KERNEL_OF_INCLUDES}
+)

--- a/kernel/mem/boot.c
+++ b/kernel/mem/boot.c
@@ -2,216 +2,231 @@
 #include <kernel/mem/boot.h>
 
 // Linked list of free memory regions
-static boot_free_region * boot_free_list = NULL;
+static boot_free_region* boot_free_list = NULL;
 
 // How big will the region be if we allocate from the end?
-static ssize_t region_size_alloc_after(struct boot_free_region *region, size_t size, unsigned int alignment)
+static ssize_t
+region_size_alloc_after(
+    struct boot_free_region* region, size_t size, unsigned int alignment
+)
 {
-  uintptr_t end = (uintptr_t)region + region->size;
-  // Get how far off from being aligned it is
-  size_t unalignment = (end-size) & ((1ull<<alignment)-1ull);
-  return region->size - size - unalignment;
+    uintptr_t end = (uintptr_t)region + region->size;
+    // Get how far off from being aligned it is
+    size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);
+    return region->size - size - unalignment;
 }
 
 // How big will the region be if we allocate from the start?
-static ssize_t region_size_alloc_before(struct boot_free_region *region, size_t size, unsigned int alignment)
+static ssize_t
+region_size_alloc_before(
+    struct boot_free_region* region, size_t size, unsigned int alignment
+)
 {
-  uintptr_t start = (uintptr_t)region;
-  // Get how far off from being aligned it is
-  size_t unalignment = (1ull<<alignment) - (start & ((1ull<<alignment)-1ull));
-  return region->size - size - unalignment;
+    uintptr_t start = (uintptr_t)region;
+    // Get how far off from being aligned it is
+    size_t unalignment = (1ull << alignment) - (start & ((1ull << alignment) - 1ull));
+    return region->size - size - unalignment;
 }
 
-static void *
-alloc_after(struct boot_free_region *region, size_t size, unsigned int alignment)
+static void*
+alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment)
 {
-  uintptr_t end = (uintptr_t)region + region->size;
-  // Get how far off from being aligned it is
-  size_t unalignment = (end-size) & ((1ull<<alignment)-1ull);
-  region->size -= (size + unalignment);
+    uintptr_t end = (uintptr_t)region + region->size;
+    // Get how far off from being aligned it is
+    size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);
+    region->size -= (size + unalignment);
 
-  if(region->size < sizeof(struct boot_free_region)) {
-    // Remove this region from the list
-    if(region->prev != NULL) {
-      region->prev->next = region->next;
-    } else {
-      // If we don't have a previous, we are the boot_free_list
-      assert(boot_free_list == region);
-      boot_free_list = region->next;
-    }
-    if(region->next != NULL) {
-      region->next->prev = region->prev;
-    }
-  }
-
-  return (void*)region + region->size;
-}
-
-static void *
-alloc_before(struct boot_free_region * region, size_t size, unsigned int alignment)
-{
-  uintptr_t start = (uintptr_t)region;
-  // Get how far off from being aligned it is
-  size_t unalignment = (1ull<<alignment) - (start & ((1ull<<alignment)-1ull));
-  size_t new_size = region->size - (size + unalignment);
-  
-  if(new_size < sizeof(struct boot_free_region)) {
-    // Remove this region from the list
-    if(region->prev) {
-      region->prev->next = region->next;
-    } else {
-      // If we don't have a previous, we are the boot free list
-      assert(boot_free_list == region);
-      boot_free_list = region->next;
-    }
-    if(region->next) {
-      region->next->prev = region->prev;
-    }
-  }
-  else {
-    // We need to move the region
-    struct boot_free_region *prev = region->prev;
-    struct boot_free_region *next = region->next;
-    struct boot_free_region *new_region = (struct boot_free_region*)((void*)region + (size + unalignment));
-    new_region->size = new_size;
-    new_region->prev = prev;
-    new_region->next = next;
-
-    if(prev != NULL) {
-      prev->next = new_region;
-    } else {
-      // If we don't have a previous, we are the boot free list
-      assert(boot_free_list == region);
-      boot_free_list = new_region;
-    }
-    if(next != NULL) {
-      next->prev = new_region;
-    }
-  }
-  return (void*)region + unalignment;
-}
-
-void * 
-boot_alloc(size_t size, unsigned int alignment) 
-{
-  struct boot_free_region *smallest_fitting = NULL;
-  size_t smallest_fit = (size_t)(-1);
-  bool should_alloc_before = false;
-
-  struct boot_free_region *curr = boot_free_list_begin();
-  while(curr != NULL) {
-    ssize_t after = region_size_alloc_after(curr,size,alignment);
-    ssize_t before = region_size_alloc_before(curr,size,alignment);
-    ssize_t greater = after > before ? after : before;
-    if(greater >= 0) {
-      if(smallest_fit > greater) {
-        smallest_fit = greater;
-        smallest_fitting = curr;
-        if(before == greater) {
-          should_alloc_before = true;
-        } else {
-          should_alloc_before = false;
+    if (region->size < sizeof(struct boot_free_region)) {
+        // Remove this region from the list
+        if (region->prev != NULL) {
+            region->prev->next = region->next;
         }
-      }
+        else {
+            // If we don't have a previous, we are the boot_free_list
+            assert(boot_free_list == region);
+            boot_free_list = region->next;
+        }
+        if (region->next != NULL) {
+            region->next->prev = region->prev;
+        }
     }
-    curr = boot_free_list_next(curr);
-  }
 
-  if(smallest_fitting == NULL) {
-    return NULL;
-  }
+    return (void*)region + region->size;
+}
 
-  if(should_alloc_before) {
-    return alloc_before(smallest_fitting,size,alignment);
-  } else {
-    return alloc_after(smallest_fitting,size,alignment);
-  }
+static void*
+alloc_before(struct boot_free_region* region, size_t size, unsigned int alignment)
+{
+    uintptr_t start = (uintptr_t)region;
+    // Get how far off from being aligned it is
+    size_t unalignment = (1ull << alignment) - (start & ((1ull << alignment) - 1ull));
+    size_t new_size = region->size - (size + unalignment);
+
+    if (new_size < sizeof(struct boot_free_region)) {
+        // Remove this region from the list
+        if (region->prev) {
+            region->prev->next = region->next;
+        }
+        else {
+            // If we don't have a previous, we are the boot free list
+            assert(boot_free_list == region);
+            boot_free_list = region->next;
+        }
+        if (region->next) {
+            region->next->prev = region->prev;
+        }
+    }
+    else {
+        // We need to move the region
+        struct boot_free_region* prev = region->prev;
+        struct boot_free_region* next = region->next;
+        struct boot_free_region* new_region =
+            (struct boot_free_region*)((void*)region + (size + unalignment));
+        new_region->size = new_size;
+        new_region->prev = prev;
+        new_region->next = next;
+
+        if (prev != NULL) {
+            prev->next = new_region;
+        }
+        else {
+            // If we don't have a previous, we are the boot free list
+            assert(boot_free_list == region);
+            boot_free_list = new_region;
+        }
+        if (next != NULL) {
+            next->prev = new_region;
+        }
+    }
+    return (void*)region + unalignment;
+}
+
+void*
+boot_alloc(size_t size, unsigned int alignment)
+{
+    struct boot_free_region* smallest_fitting = NULL;
+    size_t smallest_fit = (size_t)(-1);
+    bool should_alloc_before = false;
+
+    struct boot_free_region* curr = boot_free_list_begin();
+    while (curr != NULL) {
+        ssize_t after = region_size_alloc_after(curr, size, alignment);
+        ssize_t before = region_size_alloc_before(curr, size, alignment);
+        ssize_t greater = after > before ? after : before;
+        if (greater >= 0) {
+            if (smallest_fit > greater) {
+                smallest_fit = greater;
+                smallest_fitting = curr;
+                if (before == greater) {
+                    should_alloc_before = true;
+                }
+                else {
+                    should_alloc_before = false;
+                }
+            }
+        }
+        curr = boot_free_list_next(curr);
+    }
+
+    if (smallest_fitting == NULL) {
+        return NULL;
+    }
+
+    if (should_alloc_before) {
+        return alloc_before(smallest_fitting, size, alignment);
+    }
+    else {
+        return alloc_after(smallest_fitting, size, alignment);
+    }
 }
 
 kerror_t
-boot_free(void *start, size_t size)
+boot_free(void* start, size_t size)
 {
-  // TODO: This function could be waaaaaay smarter (see note in header)
+    // TODO: This function could be waaaaaay smarter (see note in header)
 
-  void *end = start + size;
-  struct boot_free_region *region = (struct boot_free_region *)start;
+    void* end = start + size;
+    struct boot_free_region* region = (struct boot_free_region*)start;
 
-  if(boot_free_list == NULL) {
-
-    if(size < sizeof(struct boot_free_region)) {
-      return KERR_EMPTY;
-    }
-
-    region->prev = NULL;
-    region->next = NULL;
-    region->size = size;
-    boot_free_list = region;
-    return KERR_SUCCESS;
-  }
-
-  // We need to make sure that there are no overlapping regions
-
-  struct boot_free_region *fully_before = NULL;
-  struct boot_free_region *full_after = NULL;
-
-  struct boot_free_region *curr = boot_free_list_begin();
-  while(curr != NULL) {
-    void *curr_end = curr + curr->size;
-    if(curr_end == start) {
-      // Special case: We can fully merge with the one before
-      struct boot_free_region *next = boot_free_list_next(curr);
-      if(next != NULL && (void*)next == end) {
-        // Extra special case: We can fully merge both before and after
-        curr->size += (size + next->size);
-
-        // Get rid of the "next" region
-        curr->next = next->next;
-        if(curr->next) {
-          curr->next->prev = next->prev;
+    if (boot_free_list == NULL) {
+        if (size < sizeof(struct boot_free_region)) {
+            return KERR_EMPTY;
         }
+
+        region->prev = NULL;
+        region->next = NULL;
+        region->size = size;
+        boot_free_list = region;
         return KERR_SUCCESS;
-
-      } else if(next == NULL || (void*next) > end) {
-       // Can only merge with before
-       curr->size += size;
-       return KERR_SUCCESS;
-      } else {
-        // Overlap with after (double free error)
-        return KERR_EXIST;
-      }
-    } else if(curr_end < start) {
-      fully_before = curr;
-    } else if((void*)curr > end) {
-      fully_after = curr;
-      // Regions should be in order so if we've come across our first fully after, then we've found all we need to
-      break;
-    } else {
-      // It's not fully before or fully after: OVERLAP!
-      return KERR_EXIST;
     }
-  }
 
-  // fully_before and/or fully_after should now be populated
-  if(fully_before == NULL && fully_after == NULL) {
-    // This shouldn't happen but let's be safe
-    return KERR_EXIST;
-  }
+    // We need to make sure that there are no overlapping regions
 
-  region->before = fully_before;
-  region->after = fully_after;
-  region->size = size;
-  return KERR_SUCCESS;
+    struct boot_free_region* fully_before = NULL;
+    struct boot_free_region* full_after = NULL;
+
+    struct boot_free_region* curr = boot_free_list_begin();
+    while (curr != NULL) {
+        void* curr_end = curr + curr->size;
+        if (curr_end == start) {
+            // Special case: We can fully merge with the one before
+            struct boot_free_region* next = boot_free_list_next(curr);
+            if (next != NULL && (void*)next == end) {
+                // Extra special case: We can fully merge both before and after
+                curr->size += (size + next->size);
+
+                // Get rid of the "next" region
+                curr->next = next->next;
+                if (curr->next) {
+                    curr->next->prev = next->prev;
+                }
+                return KERR_SUCCESS;
+            }
+            else if (next == NULL || (void* next) > end) {
+                // Can only merge with before
+                curr->size += size;
+                return KERR_SUCCESS;
+            }
+            else {
+                // Overlap with after (double free error)
+                return KERR_EXIST;
+            }
+        }
+        else if (curr_end < start) {
+            fully_before = curr;
+        }
+        else if ((void*)curr > end) {
+            fully_after = curr;
+            // Regions should be in order so if we've come across our first fully after,
+            // then we've found all we need to
+            break;
+        }
+        else {
+            // It's not fully before or fully after: OVERLAP!
+            return KERR_EXIST;
+        }
+    }
+
+    // fully_before and/or fully_after should now be populated
+    if (fully_before == NULL && fully_after == NULL) {
+        // This shouldn't happen but let's be safe
+        return KERR_EXIST;
+    }
+
+    region->before = fully_before;
+    region->after = fully_after;
+    region->size = size;
+    return KERR_SUCCESS;
 }
 
-struct boot_free_region *
+struct boot_free_region*
 boot_free_list_begin(void)
 {
-  return boot_free_list;
+    return boot_free_list;
 }
 
-struct boot_free_region *
-boot_free_region_next(struct boot_free_region *region)
+struct boot_free_region*
+boot_free_region_next(struct boot_free_region* region)
 {
-  return (struct boot_free_region*)region->next;
+    return (struct boot_free_region*)region->next;
 }
-

--- a/kernel/mem/boot.c
+++ b/kernel/mem/boot.c
@@ -1,0 +1,217 @@
+
+#include <kernel/mem/boot.h>
+
+// Linked list of free memory regions
+static boot_free_region * boot_free_list = NULL;
+
+// How big will the region be if we allocate from the end?
+static ssize_t region_size_alloc_after(struct boot_free_region *region, size_t size, unsigned int alignment)
+{
+  uintptr_t end = (uintptr_t)region + region->size;
+  // Get how far off from being aligned it is
+  size_t unalignment = (end-size) & ((1ull<<alignment)-1ull);
+  return region->size - size - unalignment;
+}
+
+// How big will the region be if we allocate from the start?
+static ssize_t region_size_alloc_before(struct boot_free_region *region, size_t size, unsigned int alignment)
+{
+  uintptr_t start = (uintptr_t)region;
+  // Get how far off from being aligned it is
+  size_t unalignment = (1ull<<alignment) - (start & ((1ull<<alignment)-1ull));
+  return region->size - size - unalignment;
+}
+
+static void *
+alloc_after(struct boot_free_region *region, size_t size, unsigned int alignment)
+{
+  uintptr_t end = (uintptr_t)region + region->size;
+  // Get how far off from being aligned it is
+  size_t unalignment = (end-size) & ((1ull<<alignment)-1ull);
+  region->size -= (size + unalignment);
+
+  if(region->size < sizeof(struct boot_free_region)) {
+    // Remove this region from the list
+    if(region->prev != NULL) {
+      region->prev->next = region->next;
+    } else {
+      // If we don't have a previous, we are the boot_free_list
+      assert(boot_free_list == region);
+      boot_free_list = region->next;
+    }
+    if(region->next != NULL) {
+      region->next->prev = region->prev;
+    }
+  }
+
+  return (void*)region + region->size;
+}
+
+static void *
+alloc_before(struct boot_free_region * region, size_t size, unsigned int alignment)
+{
+  uintptr_t start = (uintptr_t)region;
+  // Get how far off from being aligned it is
+  size_t unalignment = (1ull<<alignment) - (start & ((1ull<<alignment)-1ull));
+  size_t new_size = region->size - (size + unalignment);
+  
+  if(new_size < sizeof(struct boot_free_region)) {
+    // Remove this region from the list
+    if(region->prev) {
+      region->prev->next = region->next;
+    } else {
+      // If we don't have a previous, we are the boot free list
+      assert(boot_free_list == region);
+      boot_free_list = region->next;
+    }
+    if(region->next) {
+      region->next->prev = region->prev;
+    }
+  }
+  else {
+    // We need to move the region
+    struct boot_free_region *prev = region->prev;
+    struct boot_free_region *next = region->next;
+    struct boot_free_region *new_region = (struct boot_free_region*)((void*)region + (size + unalignment));
+    new_region->size = new_size;
+    new_region->prev = prev;
+    new_region->next = next;
+
+    if(prev != NULL) {
+      prev->next = new_region;
+    } else {
+      // If we don't have a previous, we are the boot free list
+      assert(boot_free_list == region);
+      boot_free_list = new_region;
+    }
+    if(next != NULL) {
+      next->prev = new_region;
+    }
+  }
+  return (void*)region + unalignment;
+}
+
+void * 
+boot_alloc(size_t size, unsigned int alignment) 
+{
+  struct boot_free_region *smallest_fitting = NULL;
+  size_t smallest_fit = (size_t)(-1);
+  bool should_alloc_before = false;
+
+  struct boot_free_region *curr = boot_free_list_begin();
+  while(curr != NULL) {
+    ssize_t after = region_size_alloc_after(curr,size,alignment);
+    ssize_t before = region_size_alloc_before(curr,size,alignment);
+    ssize_t greater = after > before ? after : before;
+    if(greater >= 0) {
+      if(smallest_fit > greater) {
+        smallest_fit = greater;
+        smallest_fitting = curr;
+        if(before == greater) {
+          should_alloc_before = true;
+        } else {
+          should_alloc_before = false;
+        }
+      }
+    }
+    curr = boot_free_list_next(curr);
+  }
+
+  if(smallest_fitting == NULL) {
+    return NULL;
+  }
+
+  if(should_alloc_before) {
+    return alloc_before(smallest_fitting,size,alignment);
+  } else {
+    return alloc_after(smallest_fitting,size,alignment);
+  }
+}
+
+kerror_t
+boot_free(void *start, size_t size)
+{
+  // TODO: This function could be waaaaaay smarter (see note in header)
+
+  void *end = start + size;
+  struct boot_free_region *region = (struct boot_free_region *)start;
+
+  if(boot_free_list == NULL) {
+
+    if(size < sizeof(struct boot_free_region)) {
+      return KERR_EMPTY;
+    }
+
+    region->prev = NULL;
+    region->next = NULL;
+    region->size = size;
+    boot_free_list = region;
+    return KERR_SUCCESS;
+  }
+
+  // We need to make sure that there are no overlapping regions
+
+  struct boot_free_region *fully_before = NULL;
+  struct boot_free_region *full_after = NULL;
+
+  struct boot_free_region *curr = boot_free_list_begin();
+  while(curr != NULL) {
+    void *curr_end = curr + curr->size;
+    if(curr_end == start) {
+      // Special case: We can fully merge with the one before
+      struct boot_free_region *next = boot_free_list_next(curr);
+      if(next != NULL && (void*)next == end) {
+        // Extra special case: We can fully merge both before and after
+        curr->size += (size + next->size);
+
+        // Get rid of the "next" region
+        curr->next = next->next;
+        if(curr->next) {
+          curr->next->prev = next->prev;
+        }
+        return KERR_SUCCESS;
+
+      } else if(next == NULL || (void*next) > end) {
+       // Can only merge with before
+       curr->size += size;
+       return KERR_SUCCESS;
+      } else {
+        // Overlap with after (double free error)
+        return KERR_EXIST;
+      }
+    } else if(curr_end < start) {
+      fully_before = curr;
+    } else if((void*)curr > end) {
+      fully_after = curr;
+      // Regions should be in order so if we've come across our first fully after, then we've found all we need to
+      break;
+    } else {
+      // It's not fully before or fully after: OVERLAP!
+      return KERR_EXIST;
+    }
+  }
+
+  // fully_before and/or fully_after should now be populated
+  if(fully_before == NULL && fully_after == NULL) {
+    // This shouldn't happen but let's be safe
+    return KERR_EXIST;
+  }
+
+  region->before = fully_before;
+  region->after = fully_after;
+  region->size = size;
+  return KERR_SUCCESS;
+}
+
+struct boot_free_region *
+boot_free_list_begin(void)
+{
+  return boot_free_list;
+}
+
+struct boot_free_region *
+boot_free_region_next(struct boot_free_region *region)
+{
+  return (struct boot_free_region*)region->next;
+}
+

--- a/kernel/mem/boot/CMakeLists.txt
+++ b/kernel/mem/boot/CMakeLists.txt
@@ -1,0 +1,15 @@
+# TODO: Select different files to be used as sources depending on Kconfig's choice of Boot Allocator
+set(
+  KERNEL_BOOT_ALLOC_SOURCES
+  # Runtime
+  free_list.c
+)
+
+list(APPEND KERNEL_BOOT_ALLOC_INCLUDES include)
+
+add_kernel_module(
+  CORE # core module
+  NAME "boot_allocator"
+  SOURCES ${KERNEL_BOOT_ALLOC_SOURCES}
+  INCLUDE_DIRS ${KERNEL_BOOT_ALLOC_INCLUDES}
+)

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -50,9 +50,7 @@ alloc_after_unalignment(
 
 // How unaligned is this allocation if we do it before the region
 static size_t
-alloc_before_unalignment(
-    struct boot_free_region* region, size_t size, unsigned int alignment
-)
+alloc_before_unalignment(struct boot_free_region* region, unsigned int alignment)
 {
     void* start = (void*)region;
     return (size_t)(1ull << alignment)
@@ -65,7 +63,6 @@ region_size_alloc_after(
     struct boot_free_region* region, size_t size, unsigned int alignment
 )
 {
-    uintptr_t end = (uintptr_t)region + region->size;
     size_t unalignment = alloc_after_unalignment(region, size, alignment);
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
@@ -76,15 +73,13 @@ region_size_alloc_before(
     struct boot_free_region* region, size_t size, unsigned int alignment
 )
 {
-    uintptr_t start = (uintptr_t)region;
-    size_t unalignment = alloc_before_unalignment(region, size, alignment);
+    size_t unalignment = alloc_before_unalignment(region, alignment);
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
 
 static void*
 alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment)
 {
-    uintptr_t end = (uintptr_t)region + region->size;
     // Get how far off from being aligned it is
     // TODO: (if unalignment > sizeof(struct boot_free_region)
     //        we should split the region in the free list to waste less memory.
@@ -113,9 +108,8 @@ alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment
 static void*
 alloc_before(struct boot_free_region* region, size_t size, unsigned int alignment)
 {
-    uintptr_t start = (uintptr_t)region;
     // Get how far off from being aligned it is
-    size_t unalignment = alloc_before_unalignment(region, size, alignment);
+    size_t unalignment = alloc_before_unalignment(region, alignment);
     size_t new_size = region->size - (size + unalignment);
 
     if (new_size < sizeof(struct boot_free_region)) {

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -1,6 +1,6 @@
 
+#include "kernel/mem/boot.h"
 #include <assert.h>
-#include <kernel/mem/boot.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -11,6 +11,10 @@
  */
 
 // Doubly-linked list of free regions in physical memory
+// INVARIANTS:
+//     These regions must be in order with increasing addresses.
+//     Each struct should be allocated at the start of the region it defines.
+//     (E.g. &boot_free_region = the start address of that region)
 struct boot_free_region {
     struct boot_free_region* next;
     struct boot_free_region* prev;
@@ -21,16 +25,33 @@ struct boot_free_region {
 /*
  * Get the first (lowest address) region in the free list
  */
-struct boot_free_region* boot_free_list_begin(void);
+static struct boot_free_region* boot_free_list_begin(void);
 
 /*
  * Get the next region (next higher address) in the free list (or NULL)
  */
-struct boot_free_region* boot_free_list_next(struct boot_free_region* region);
+static struct boot_free_region* boot_free_list_next(struct boot_free_region* region);
 //
 
 // Linked list of free memory regions
 static struct boot_free_region* boot_free_list = NULL;
+
+// How unaligned is this allocation if we do it after the region
+static size_t alloc_after_unalignment(
+    struct boot_free_region *region, size_t size, unsigned int alignment)
+{
+    void *start = (void*)region;
+    void *end = start + region->size;
+    return (size_t)(((uintptr_t)end - size) & ((1ull << alignment) - 1ull));
+}
+
+// How unaligned is this allocation if we do it before the region
+static size_t alloc_before_unalignment(
+    struct boot_free_region *region, size_t size, unsigned int alignment)
+{
+    void *start = (void*)region;
+    return (size_t)(1ull << alignment) - ((uintptr_t)start & ((1ull << alignment) - 1ull));
+}
 
 // How big will the region be if we allocate from the end?
 static ssize_t
@@ -39,8 +60,7 @@ region_size_alloc_after(
 )
 {
     uintptr_t end = (uintptr_t)region + region->size;
-    // Get how far off from being aligned it is
-    size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);
+    size_t unalignment = alloc_after_unalignment(region,size,alignment); 
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
 
@@ -51,8 +71,7 @@ region_size_alloc_before(
 )
 {
     uintptr_t start = (uintptr_t)region;
-    // Get how far off from being aligned it is
-    size_t unalignment = (1ull << alignment) - (start & ((1ull << alignment) - 1ull));
+    size_t unalignment = alloc_before_unalignment(region,size,alignment); 
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
 
@@ -64,7 +83,7 @@ alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment
     // TODO: (if unalignment > sizeof(struct boot_free_region)
     //        we should split the region in the free list to waste less memory.
     //        This is especially important for page allocations)
-    size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);
+    size_t unalignment = alloc_after_unalignment(region,size,alignment);
     region->size -= (size + unalignment);
 
     if (region->size < sizeof(struct boot_free_region)) {
@@ -90,7 +109,7 @@ alloc_before(struct boot_free_region* region, size_t size, unsigned int alignmen
 {
     uintptr_t start = (uintptr_t)region;
     // Get how far off from being aligned it is
-    size_t unalignment = (1ull << alignment) - (start & ((1ull << alignment) - 1ull));
+    size_t unalignment = alloc_before_unalignment(region,size,alignment);
     size_t new_size = region->size - (size + unalignment);
 
     if (new_size < sizeof(struct boot_free_region)) {
@@ -141,6 +160,7 @@ boot_alloc(size_t size, unsigned int alignment)
 
     struct boot_free_region* curr = boot_free_list_begin();
     while (curr != NULL) {
+        /* Find which allocation type leaves the region larger */
         ssize_t after = region_size_alloc_after(curr, size, alignment);
         ssize_t before = region_size_alloc_before(curr, size, alignment);
         ssize_t greater = after > before ? after : before;
@@ -148,12 +168,7 @@ boot_alloc(size_t size, unsigned int alignment)
             if (smallest_fit > (size_t)greater) {
                 smallest_fit = (size_t)greater;
                 smallest_fitting = curr;
-                if (before == greater) {
-                    should_alloc_before = true;
-                }
-                else {
-                    should_alloc_before = false;
-                }
+                should_alloc_before = (after != greater);
             }
         }
         curr = boot_free_list_next(curr);
@@ -166,9 +181,7 @@ boot_alloc(size_t size, unsigned int alignment)
     if (should_alloc_before) {
         return alloc_before(smallest_fitting, size, alignment);
     }
-    else {
-        return alloc_after(smallest_fitting, size, alignment);
-    }
+    return alloc_after(smallest_fitting, size, alignment);
 }
 
 kerror_t
@@ -218,10 +231,8 @@ boot_free(void* start, size_t size)
                 curr->size += size;
                 return KERR_SUCCESS;
             }
-            else {
-                // Overlap with after (double free error)
-                return KERR_EXIST;
-            }
+            // Overlap with after (double free error)
+            return KERR_EXIST;
         }
         else if (curr_end < start) {
             fully_before = curr;
@@ -232,15 +243,14 @@ boot_free(void* start, size_t size)
             // then we've found all we need to
             break;
         }
-        else {
-            // It's not fully before or fully after: OVERLAP!
-            return KERR_EXIST;
-        }
+        // It's not fully before or fully after: OVERLAP!
+        return KERR_EXIST;
     }
 
     // fully_before and/or fully_after should now be populated
     if (fully_before == NULL && fully_after == NULL) {
         // This shouldn't happen but let's be safe
+        printk("This shouldn't happen: %s\n" __FILE__);
         return KERR_EXIST;
     }
 
@@ -262,7 +272,7 @@ boot_free_list_begin(void)
 struct boot_free_region*
 boot_free_list_next(struct boot_free_region* region)
 {
-    return (struct boot_free_region*)region->next;
+    return region->next;
 }
 
 kerror_t

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -22,6 +22,10 @@ struct boot_free_region {
     size_t size;
 };
 
+// Linked list of free memory regions
+static struct boot_free_region* boot_free_list = NULL;
+
+
 // Forward declarations
 /*
  * Get the first (lowest address) region in the free list
@@ -32,10 +36,6 @@ static struct boot_free_region* boot_free_list_begin(void);
  * Get the next region (next higher address) in the free list (or NULL)
  */
 static struct boot_free_region* boot_free_list_next(struct boot_free_region* region);
-//
-
-// Linked list of free memory regions
-static struct boot_free_region* boot_free_list = NULL;
 
 // How unaligned is this allocation if we do it after the region
 static size_t

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -1,5 +1,6 @@
 
 #include "kernel/mem/boot.h"
+
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -37,20 +38,25 @@ static struct boot_free_region* boot_free_list_next(struct boot_free_region* reg
 static struct boot_free_region* boot_free_list = NULL;
 
 // How unaligned is this allocation if we do it after the region
-static size_t alloc_after_unalignment(
-    struct boot_free_region *region, size_t size, unsigned int alignment)
+static size_t
+alloc_after_unalignment(
+    struct boot_free_region* region, size_t size, unsigned int alignment
+)
 {
-    void *start = (void*)region;
-    void *end = start + region->size;
+    void* start = (void*)region;
+    void* end = start + region->size;
     return (size_t)(((uintptr_t)end - size) & ((1ull << alignment) - 1ull));
 }
 
 // How unaligned is this allocation if we do it before the region
-static size_t alloc_before_unalignment(
-    struct boot_free_region *region, size_t size, unsigned int alignment)
+static size_t
+alloc_before_unalignment(
+    struct boot_free_region* region, size_t size, unsigned int alignment
+)
 {
-    void *start = (void*)region;
-    return (size_t)(1ull << alignment) - ((uintptr_t)start & ((1ull << alignment) - 1ull));
+    void* start = (void*)region;
+    return (size_t)(1ull << alignment)
+           - ((uintptr_t)start & ((1ull << alignment) - 1ull));
 }
 
 // How big will the region be if we allocate from the end?
@@ -60,7 +66,7 @@ region_size_alloc_after(
 )
 {
     uintptr_t end = (uintptr_t)region + region->size;
-    size_t unalignment = alloc_after_unalignment(region,size,alignment); 
+    size_t unalignment = alloc_after_unalignment(region, size, alignment);
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
 
@@ -71,7 +77,7 @@ region_size_alloc_before(
 )
 {
     uintptr_t start = (uintptr_t)region;
-    size_t unalignment = alloc_before_unalignment(region,size,alignment); 
+    size_t unalignment = alloc_before_unalignment(region, size, alignment);
     return ((ssize_t)region->size - (ssize_t)(size + unalignment));
 }
 
@@ -83,7 +89,7 @@ alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment
     // TODO: (if unalignment > sizeof(struct boot_free_region)
     //        we should split the region in the free list to waste less memory.
     //        This is especially important for page allocations)
-    size_t unalignment = alloc_after_unalignment(region,size,alignment);
+    size_t unalignment = alloc_after_unalignment(region, size, alignment);
     region->size -= (size + unalignment);
 
     if (region->size < sizeof(struct boot_free_region)) {
@@ -109,7 +115,7 @@ alloc_before(struct boot_free_region* region, size_t size, unsigned int alignmen
 {
     uintptr_t start = (uintptr_t)region;
     // Get how far off from being aligned it is
-    size_t unalignment = alloc_before_unalignment(region,size,alignment);
+    size_t unalignment = alloc_before_unalignment(region, size, alignment);
     size_t new_size = region->size - (size + unalignment);
 
     if (new_size < sizeof(struct boot_free_region)) {

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -2,6 +2,7 @@
 #include <kernel/mem/boot.h>
 #include<stdint.h>
 #include<assert.h>
+#include<stdio.h>
 
 /*
  * This file implements "boot_alloc" and "boot_free"
@@ -260,3 +261,19 @@ boot_free_list_next(struct boot_free_region* region)
 {
     return (struct boot_free_region*)region->next;
 }
+
+kerror_t boot_mem_dump(void)
+{
+  printk("--- BOOT ALLOC FREE REGIONS ---\n");
+  struct boot_free_region *curr = boot_free_list_begin();
+  while(curr != NULL) {
+    void *start = (void*)curr;
+    size_t size = curr->size;
+    void *end = start + size;
+    printk("[%p - %p] size = (%p bytes)\n", start, end, (void*)(uintptr_t)size);
+    curr = boot_free_list_next(curr);
+  }
+  printk("-------------------------------\n");
+  return KERR_SUCCESS;
+}
+

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -25,7 +25,6 @@ struct boot_free_region {
 // Linked list of free memory regions
 static struct boot_free_region* boot_free_list = NULL;
 
-
 // Forward declarations
 /*
  * Get the first (lowest address) region in the free list

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -61,7 +61,7 @@ alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment
 {
     uintptr_t end = (uintptr_t)region + region->size;
     // Get how far off from being aligned it is
-    // TODO: (if unalignment > sizeof(struct boot_free_region) 
+    // TODO: (if unalignment > sizeof(struct boot_free_region)
     //        we should split the region in the free list to waste less memory.
     //        This is especially important for page allocations)
     size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);

--- a/kernel/of/CMakeLists.txt
+++ b/kernel/of/CMakeLists.txt
@@ -2,6 +2,7 @@ set(
   KERNEL_OF_SOURCES
   # Runtime
   fdt.c
+  fdt_mem.c
 )
 
 list(APPEND KERNEL_OF_INCLUDES include)

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -366,7 +366,11 @@ fdt_node_get_parents(
         return 0;
     }
 
-    struct fdt_node* curr_branch[max_depth + 1]; // C99 feature
+#ifdef __STD_C_NO_VLA__
+#error "Automatic storage duration VLA's are not supported!"
+#else
+    struct fdt_node* curr_branch[max_depth + 1];
+#endif
 
     int depth = 0;
     struct fdt_node* curr = fdt_node_begin(fdt);

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -177,7 +177,7 @@ fdt_next_reserve_entry(struct fdt* fdt, struct fdt_reserve_entry* entry)
 void*
 fdt_reserve_entry_address(struct fdt_reserve_entry* entry)
 {
-#if CONFIG_64_BIT 
+#if CONFIG_64_BIT
     return (void*)be64toh(entry->address);
 #else
     return (void*)be32toh(entry->address);
@@ -370,7 +370,7 @@ fdt_node_get_parents(
     }
 
 #ifdef __STD_C_NO_VLA__
-#error "Automatic storage duration VLA's are not supported!"
+#  error "Automatic storage duration VLA's are not supported!"
 #else
     struct fdt_node* curr_branch[max_depth + 1];
 #endif

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -356,9 +356,9 @@ fdt_node_get_parents(
     size_t parents_len
 )
 {
-    // We can only traverse the FLAT device tree in forward order, so this is going to be
-    // painful (Also a big reason we want to unflatten the tree ASAP once we have memory
-    // allocation)
+    // We can only traverse the FLAT device tree in forward order, so this is going to
+    // be painful (Also a big reason we want to unflatten the tree ASAP once we have
+    // memory allocation)
 
     int max_depth = fdt_max_depth(fdt);
     if (max_depth < 0) {

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -177,6 +177,20 @@ fdt_next_reserve_entry(struct fdt* fdt, struct fdt_reserve_entry* entry)
     return entry;
 }
 
+void*
+fdt_reserve_entry_address(struct fdt_reserve_entry* entry)
+{
+    // TODO: 32-bit systems should use be32toh
+    return (void*)(uintptr_t)be64toh(entry->address);
+}
+
+size_t
+fdt_reserve_entry_size(struct fdt_reserve_entry* entry)
+{
+    // TODO: 32-bit systems should use be32toh
+    return (size_t)be64toh(entry->size);
+}
+
 size_t
 fdt_prop_val_len(struct fdt_prop* prop)
 {

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -513,13 +513,13 @@ fdt_find_node_by_device_type(struct fdt* fdt, struct fdt_node* start, const char
         struct fdt_prop* prop = fdt_get_prop_by_name(fdt, node, NULL, "device_type");
         if (prop != NULL) {
             size_t prop_len = fdt_prop_val_len(prop);
-            void *prop_val = fdt_prop_val(prop);
+            void* prop_val = fdt_prop_val(prop);
             // Consider equal even if '\0' is omitted in the property
-            if (prop_len == len+1 || prop_len == len) {
-              if(memcmp(type, prop_val, prop_len) == 0) {
-                return node;
-              }
-            }  
+            if (prop_len == len + 1 || prop_len == len) {
+                if (memcmp(type, prop_val, prop_len) == 0) {
+                    return node;
+                }
+            }
         }
         node = fdt_next_node(fdt, node, NULL);
     }
@@ -648,89 +648,91 @@ fdt_prop_get_cell(struct fdt_prop* prop, size_t index)
     return be32toh(val[index]);
 }
 
-size_t 
-fdt_node_num_register_blocks(struct fdt *fdt, struct fdt_node *node)
+size_t
+fdt_node_num_register_blocks(struct fdt* fdt, struct fdt_node* node)
 {
-  struct fdt_prop *reg = fdt_get_prop_by_name(fdt, node, NULL, "reg");
+    struct fdt_prop* reg = fdt_get_prop_by_name(fdt, node, NULL, "reg");
 
-  if(reg == NULL) {
-    return (size_t)0;
-  }
+    if (reg == NULL) {
+        return (size_t)0;
+    }
 
-  uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
-  uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
-  uint32_t reg_block_cells = address_cells + size_cells;
+    uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t reg_block_cells = address_cells + size_cells;
 
-  if(reg_block_cells == 0) {
-    return 0;
-  }
+    if (reg_block_cells == 0) {
+        return 0;
+    }
 
-  // 4 bytes per cell
-  size_t reg_cell_len = fdt_prop_val_len(reg) >> 2;
+    // 4 bytes per cell
+    size_t reg_cell_len = fdt_prop_val_len(reg) >> 2;
 
-  return reg_cell_len / reg_block_cells;
+    return reg_cell_len / reg_block_cells;
 }
 
-void fdt_node_get_register_block(struct fdt *fdt, struct fdt_node *node, size_t index, void ** address, size_t * size) 
+void
+fdt_node_get_register_block(
+    struct fdt* fdt, struct fdt_node* node, size_t index, void** address, size_t* size
+)
 {
-  struct fdt_prop *reg = fdt_get_prop_by_name(fdt, node, NULL, "reg");
+    struct fdt_prop* reg = fdt_get_prop_by_name(fdt, node, NULL, "reg");
 
-  if(reg == NULL) {
-    goto err_exit;
-  }
+    if (reg == NULL) {
+        goto err_exit;
+    }
 
-  uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
-  uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
-  uint32_t reg_block_cells = address_cells + size_cells;
+    uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t reg_block_cells = address_cells + size_cells;
 
-  void *raw_reg = fdt_prop_val(reg);
-  size_t raw_reg_len = fdt_prop_val_len(reg);
- 
-  // How many bytes do we need "reg" to be so we can access index safely?
-  size_t min_size_for_index = (index * reg_block_cells * 4);
+    void* raw_reg = fdt_prop_val(reg);
+    size_t raw_reg_len = fdt_prop_val_len(reg);
 
-  if(raw_reg_len < min_size_for_index) {
-    goto err_exit;
-  }
+    // How many bytes do we need "reg" to be so we can access index safely?
+    size_t min_size_for_index = (index * reg_block_cells * 4);
 
-  // Get a pointer to the start of the address in the property
-  uint32_t * address_ptr = ((uint32_t*)raw_reg) + (index * reg_block_cells);
-  // Size cells come after address cells
-  uint32_t * size_ptr = address_ptr + address_cells;
+    if (raw_reg_len < min_size_for_index) {
+        goto err_exit;
+    }
 
-  uint32_t msig_cell; // Most significant cell in 64-bit
-  uint32_t lsig_cell; // Least significant cell in 64-bit
+    // Get a pointer to the start of the address in the property
+    uint32_t* address_ptr = ((uint32_t*)raw_reg) + (index * reg_block_cells);
+    // Size cells come after address cells
+    uint32_t* size_ptr = address_ptr + address_cells;
 
-  switch(address_cells) {
-    case 1:
-      *address = (void*)(uintptr_t)be32toh(*address_ptr);
-      break;
-    case 2:
-      msig_cell = be32toh(address_ptr[0]);
-      lsig_cell = be32toh(address_ptr[1]);
-      *address = (void*)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
-      break;
-    default:
-      goto err_exit;
-  }
+    uint32_t msig_cell; // Most significant cell in 64-bit
+    uint32_t lsig_cell; // Least significant cell in 64-bit
 
-  switch(size_cells) {
-    case 1:
-      *size = (size_t)be32toh(*size_ptr);
-      break;
-    case 2:
-      msig_cell = be32toh(size_ptr[0]);
-      lsig_cell = be32toh(size_ptr[1]);
-      *size = (size_t)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
-      break;
-    default:
-      goto err_exit;
-  }
+    switch (address_cells) {
+        case 1:
+            *address = (void*)(uintptr_t)be32toh(*address_ptr);
+            break;
+        case 2:
+            msig_cell = be32toh(address_ptr[0]);
+            lsig_cell = be32toh(address_ptr[1]);
+            *address = (void*)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
+            break;
+        default:
+            goto err_exit;
+    }
 
-  return;
+    switch (size_cells) {
+        case 1:
+            *size = (size_t)be32toh(*size_ptr);
+            break;
+        case 2:
+            msig_cell = be32toh(size_ptr[0]);
+            lsig_cell = be32toh(size_ptr[1]);
+            *size = (size_t)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
+            break;
+        default:
+            goto err_exit;
+    }
+
+    return;
 err_exit:
-  *address = NULL;
-  *size = (size_t)0;
-  return;
+    *address = NULL;
+    *size = (size_t)0;
+    return;
 }
-

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -610,7 +610,7 @@ fdt_node_get_size_cells(struct fdt* fdt, struct fdt_node* node)
 
     if (prop == NULL) {
         // Linux default
-        return 2;
+        return 1;
     }
 
     size_t num_cells = fdt_prop_num_cells(prop);
@@ -631,7 +631,7 @@ fdt_node_get_size_cells(struct fdt* fdt, struct fdt_node* node)
 size_t
 fdt_prop_num_cells(struct fdt_prop* prop)
 {
-    return fdt_prop_val_len(prop) >> 2;
+    return fdt_prop_val_len(prop) / sizeof(uint32_t);
 }
 
 uint32_t
@@ -658,15 +658,14 @@ fdt_node_num_register_blocks(struct fdt* fdt, struct fdt_node* node)
     }
 
     uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
-    uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t size_cells = fdt_node_get_size_cells(fdt, node);
     uint32_t reg_block_cells = address_cells + size_cells;
 
     if (reg_block_cells == 0) {
         return 0;
     }
 
-    // 4 bytes per cell
-    size_t reg_cell_len = fdt_prop_val_len(reg) >> 2;
+    size_t reg_cell_len = fdt_prop_num_cells(reg);
 
     return reg_cell_len / reg_block_cells;
 }
@@ -683,7 +682,7 @@ fdt_node_get_register_block(
     }
 
     uint32_t address_cells = fdt_node_get_address_cells(fdt, node);
-    uint32_t size_cells = fdt_node_get_address_cells(fdt, node);
+    uint32_t size_cells = fdt_node_get_size_cells(fdt, node);
     uint32_t reg_block_cells = address_cells + size_cells;
 
     void* raw_reg = fdt_prop_val(reg);

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -369,11 +369,7 @@ fdt_node_get_parents(
         return 0;
     }
 
-#ifdef __STD_C_NO_VLA__
-#  error "Automatic storage duration VLA's are not supported!"
-#else
     struct fdt_node* curr_branch[max_depth + 1];
-#endif
 
     int depth = 0;
     struct fdt_node* curr = fdt_node_begin(fdt);

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -423,7 +423,7 @@ fdt_node_name(struct fdt_node* node)
 #else
     // If the first character is the terminator, replace it with a debug name
     // NOTE: different nodes can appear to have the same name with this scheme
-    return *(char*)node->unit_name != '\0' ? node->unit_name : "{DEBUG: Nameless Node}";
+    return node->unit_name[0] != '\0' ? node->unit_name : "{DEBUG: Nameless Node}";
 #endif
 }
 

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -22,10 +22,7 @@ fdt_memrsv_ptr_invalid(struct fdt* fdt, void* ptr)
     // so we're just going to make sure it doesn't run into the structure block
     void* end = ((void*)fdt) + be32toh(fdt->off_dt_struct);
 
-    if (ptr < start || ptr >= end) {
-        return true;
-    }
-    return false;
+    return (ptr < start) || (ptr >= end);
 }
 
 static uint32_t*
@@ -180,15 +177,21 @@ fdt_next_reserve_entry(struct fdt* fdt, struct fdt_reserve_entry* entry)
 void*
 fdt_reserve_entry_address(struct fdt_reserve_entry* entry)
 {
-    // TODO: 32-bit systems should use be32toh
-    return (void*)(uintptr_t)be64toh(entry->address);
+#if CONFIG_64_BIT 
+    return (void*)be64toh(entry->address);
+#else
+    return (void*)be32toh(entry->address);
+#endif
 }
 
 size_t
 fdt_reserve_entry_size(struct fdt_reserve_entry* entry)
 {
-    // TODO: 32-bit systems should use be32toh
+#if CONFIG_64_BIT
     return (size_t)be64toh(entry->size);
+#else
+    return (size_t)be32toh(entry->size);
+#endif
 }
 
 size_t

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -703,21 +703,16 @@ fdt_node_get_register_block(
     }
 
     // Get a pointer to the start of the address in the property
-    uint32_t* address_ptr = ((uint32_t*)raw_reg) + (index * reg_block_cells);
+    void* address_ptr = raw_reg + (index * reg_block_cells);
     // Size cells come after address cells
-    uint32_t* size_ptr = address_ptr + address_cells;
-
-    uint32_t msig_cell; // Most significant cell in 64-bit
-    uint32_t lsig_cell; // Least significant cell in 64-bit
+    void* size_ptr = address_ptr + (address_cells * sizeof(uint32_t));
 
     switch (address_cells) {
         case 1:
-            *address = (void*)(uintptr_t)be32toh(*address_ptr);
+            *address = (void*)(uintptr_t)be32toh(*(uint32_t*)address_ptr);
             break;
         case 2:
-            msig_cell = be32toh(address_ptr[0]);
-            lsig_cell = be32toh(address_ptr[1]);
-            *address = (void*)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
+            *address = (void*)(uintptr_t)be64toh(*(uint64_t*)address_ptr);
             break;
         default:
             goto err_exit;
@@ -725,12 +720,10 @@ fdt_node_get_register_block(
 
     switch (size_cells) {
         case 1:
-            *size = (size_t)be32toh(*size_ptr);
+            *size = (size_t)(uintptr_t)be32toh(*(uint32_t*)size_ptr);
             break;
         case 2:
-            msig_cell = be32toh(size_ptr[0]);
-            lsig_cell = be32toh(size_ptr[1]);
-            *size = (size_t)(((uint64_t)msig_cell << 32) | (uint64_t)lsig_cell);
+            *size = (size_t)(uintptr_t)be64toh(*(uint64_t*)size_ptr);
             break;
         default:
             goto err_exit;

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -356,7 +356,7 @@ fdt_node_get_parents(
     size_t parents_len
 )
 {
-    // We can only traverse the FLAT device tree in forward order, so this is gonna be
+    // We can only traverse the FLAT device tree in forward order, so this is going to be
     // painful (Also a big reason we want to unflatten the tree ASAP once we have memory
     // allocation)
 

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -115,6 +115,30 @@ fdt_size(struct fdt* fdt)
     return (size_t)be32toh(fdt->totalsize);
 }
 
+struct fdt_reserve_entry *
+fdt_reserve_entry_begin(struct fdt *fdt) 
+{ 
+    struct fdt_reserve_entry *entry = (struct fdt_reserve_entry*)(((void*)fdt) + be32toh(fdt->off_mem_rsvmap));
+
+    if(entry->address == NULL && entry->size == NULL) {
+      return NULL;
+    }
+
+    return entry;
+}
+
+struct fdt_reserve_entry *
+fdt_next_reserve_entry(struct fdt *fdt, struct fdt_reserve_entry *entry)
+{
+    entry = (struct fdt_reserve_entry*)(((void*)entry) + 16ull);
+
+    if(entry->address == NULL && entry->size == NULL) {
+      return NULL;
+    }
+
+    return entry;
+}
+
 size_t
 fdt_prop_val_len(struct fdt_prop* prop)
 {

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -1,0 +1,8 @@
+
+#include <kernel/of/fdt_mem.h>
+
+/*
+ * Use the FDT to hand off free memory regions to the "boot" memory allocator
+ */
+kerror_t fdt_boot_mem_init(struct fdt *fdt);
+

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -1,5 +1,6 @@
 
 #include "kernel/of/fdt_mem.h"
+
 #include <stdio.h>
 
 // Helper function which decides how to deal with overlapping reserved regions
@@ -32,7 +33,7 @@ trim_or_split_around_reserved(
             *size_ptr = 0;
             return false;
         }
-        
+
         // Trim from below
         *start_ptr = resv_end;
         *size_ptr = (size_t)(end - resv_end);

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -4,5 +4,11 @@
 /*
  * Use the FDT to hand off free memory regions to the "boot" memory allocator
  */
-kerror_t fdt_boot_mem_init(struct fdt *fdt);
-
+kerror_t
+fdt_boot_mem_init(struct fdt* fdt)
+{
+    struct fdt_node* mem_node = fdt_find_node_by_device_type(fdt, NULL, "memory");
+    while (mem_node != NULL) {
+        mem_node = fdt_find_node_by_device_type(fdt, mem_node, "memory");
+    }
+}

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -1,5 +1,6 @@
 
 #include <kernel/of/fdt_mem.h>
+#include <stdio.h>
 
 // Try to free this region (return the number of bytes successfully freed)
 static size_t
@@ -66,6 +67,10 @@ fdt_boot_mem_init(struct fdt* fdt)
     struct fdt_node* mem_node = fdt_find_node_by_device_type(fdt, NULL, "memory");
     while (mem_node != NULL) {
         // TODO: Actually free memory
+        void *address;
+        size_t size;
+        fdt_node_get_register_block(fdt,mem_node,0,&address,&size);
+        printk("memory_node: {addr = %p, size = %p}\n", (void*)address, (void*)(uintptr_t)size);
         mem_node = fdt_find_node_by_device_type(fdt, mem_node, "memory");
     }
     return KERR_SUCCESS;

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -2,52 +2,126 @@
 #include <kernel/of/fdt_mem.h>
 #include <stdio.h>
 
+// Helper function which decides how to deal with overlapping reserved regions
+// Returns true if split, else false
+static bool trim_or_split_around_reserved(
+    void **start_ptr, size_t *size_ptr, // Original Region to be trimmed or split
+    void **split_start_ptr, size_t *split_size_ptr, // Storage for second region if split occurs
+    void *resv_start, size_t resv_size // The reserved region to trim or split around
+  ) 
+{
+    void *start = *start_ptr;
+    size_t size = *size_ptr;
+
+    void* end = start + size;
+    void* resv_end = resv_start + resv_size;
+
+    if (resv_end <= start || resv_start > end) {
+        // No overlap with this reserve entry
+        return false;
+    }
+    else if (resv_start <= start) {
+        // Fully covering or trim from below
+        if (resv_end >= end) {
+            // Fully covering (this region is entirely reserved)
+            *start_ptr = NULL;
+            *size_ptr = 0;
+            return false;
+        }
+        else {
+            // Trim from below
+            *start_ptr = resv_end;
+            *size_ptr = (size_t)(end - resv_end);
+            return false;
+        }
+    }
+    else {
+        // Split into two or trim from above
+        if (resv_end < end) {
+            // Split into two
+            // Region1 = [start,resv_start)
+            // Region2 = [resv_end,end)
+            *size_ptr = (size_t)(resv_start - start);
+            *split_start_ptr = resv_end;
+            *split_size_ptr = (size_t)(end - *split_start_ptr);
+            return true;
+        }
+        else {
+            // Trim from above
+            end = resv_start;
+            *size_ptr = (size_t)(end - start);
+            return false;
+        }
+    }
+
+    // Should be unreachable
+}
+
 // Try to free this region (return the number of bytes successfully freed)
 static size_t
 try_boot_free_region(struct fdt* fdt, void* start, size_t size)
 {
-    void* end = start + size;
+    // Should be unnecessary (but it's worth checking incase someone messes up)
+    if(size == 0) {
+      return (size_t)0;
+    }
 
-    // See if we overlap any of the reserve_entries
+    // Buffers for a second region if we get split into two
+    void *split_start;
+    size_t split_size;
+
+    // Check if this is a region before the end of the kernel (protects the kernel and firmware which is before it)
+    extern int __kernel_end[];
+    if(start < (void*)__kernel_end) {
+      if((void*)(start + size) <= (void*)__kernel_end) {
+        // Entirely before the kernel
+        return (size_t)0;
+      } else {
+        // Need to trim before
+        size = (size_t)((start + size) - (void*)__kernel_end);
+        start = (void*)__kernel_end;
+      }
+    } else {
+      // No addresses lower than the end of the kernel (so no overlap)
+    }
+
+    // Handle the reserve entries in the FDT
     struct fdt_reserve_entry* entry = fdt_reserve_entry_begin(fdt);
     while (entry != NULL) {
         void* resv_start = fdt_reserve_entry_address(entry);
         size_t resv_size = fdt_reserve_entry_size(entry);
 
-        void* resv_end = resv_start + resv_size;
-
-        if (resv_end <= start || resv_start > end) {
-            // No overlap with this reserve entry
-        }
-        else if (resv_start <= start) {
-            // Fully covering or trim from below
-            if (resv_end >= end) {
-                // Fully covering (this region is entirely reserved)
-                return (size_t)0;
-            }
-            else {
-                // Trim from below
-                start = resv_end;
-                size = (size_t)(end - resv_end);
-            }
-        }
-        else {
-            // Split into two or trim from above
-            if (resv_end < end) {
-                // Split into two
-                // Region1 = [start,resv_start)
-                // Region2 = [resv_end,end)
-                return try_boot_free_region(fdt, start, (size_t)(resv_start - start))
-                       + try_boot_free_region(fdt, resv_end, (size_t)(end - resv_end));
-            }
-            else {
-                // Trim from above
-                end = resv_start;
-                size = (size_t)(end - start);
-            }
+        if(trim_or_split_around_reserved(&start, &size, &split_start, &split_size, resv_start, resv_size)) {
+          // We split into 2 regions
+          return try_boot_free_region(fdt, start, size)
+               + try_boot_free_region(fdt, split_start, split_size);
+        } else {
+          if(size == 0) {
+            // We got fully trimmed
+            return (size_t)0;
+          } else {
+            // We're still one contiguous region (continue)
+          }
         }
 
         entry = fdt_next_reserve_entry(fdt, entry);
+    }
+
+    // Make sure we don't free the FDT blob itself
+    void *fdt_resv_start = (void*)fdt;
+    size_t fdt_resv_size = fdt_size(fdt);
+
+    if(trim_or_split_around_reserved(&start, &size, &split_start, &split_size, fdt_resv_start, fdt_resv_size)) {
+      // We split into 2 regions
+      return try_boot_free_region(fdt, start, size)
+           + try_boot_free_region(fdt, split_start, split_size);
+    } else {
+      if(size == 0) {
+        // We got fully trimmed
+        return (size_t)0;
+      } else {
+        // We're still one contiguous region (continue)
+      }
     }
 
     // We made it through (possibly shrunk)
@@ -65,13 +139,39 @@ kerror_t
 fdt_boot_mem_init(struct fdt* fdt)
 {
     struct fdt_node* mem_node = fdt_find_node_by_device_type(fdt, NULL, "memory");
+
+    size_t total_mem_seen = 0;
+    size_t total_mem_freed = 0;
+
     while (mem_node != NULL) {
         // TODO: Actually free memory
-        void *address;
-        size_t size;
-        fdt_node_get_register_block(fdt,mem_node,0,&address,&size);
-        printk("memory_node: {addr = %p, size = %p}\n", (void*)address, (void*)(uintptr_t)size);
+        size_t num_register_blocks = fdt_node_num_register_blocks(fdt, mem_node);
+
+        for (size_t i = 0; i < num_register_blocks; i++) {
+            void* address;
+            size_t size;
+
+            fdt_node_get_register_block(fdt, mem_node, 0, &address, &size);
+            total_mem_seen += size;
+
+            printk(
+                "memory_node: (%s)[%c] {addr = %p, size = %p}\n",
+                fdt_node_name(mem_node),
+                '0' + (unsigned char)i,
+                (void*)address,
+                (void*)(uintptr_t)size
+            );
+
+            size_t freed = try_boot_free_region(fdt, address, size);
+            total_mem_freed += freed;
+        }
+
         mem_node = fdt_find_node_by_device_type(fdt, mem_node, "memory");
     }
+
+    printk("[FDT] Freed Memory Regions:\n");
+    printk("[FDT] \tTotal Memory = (%p bytes)\n", (void*)(uintptr_t)total_mem_seen);
+    printk("[FDT] \tFreed Memory = (%p bytes)\n", (void*)(uintptr_t)total_mem_freed);
+
     return KERR_SUCCESS;
 }

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -1,5 +1,5 @@
 
-#include <kernel/of/fdt_mem.h>
+#include "kernel/of/fdt_mem.h"
 #include <stdio.h>
 
 // Helper function which decides how to deal with overlapping reserved regions
@@ -32,33 +32,28 @@ trim_or_split_around_reserved(
             *size_ptr = 0;
             return false;
         }
-        else {
-            // Trim from below
-            *start_ptr = resv_end;
-            *size_ptr = (size_t)(end - resv_end);
-            return false;
-        }
-    }
-    else {
-        // Split into two or trim from above
-        if (resv_end < end) {
-            // Split into two
-            // Region1 = [start,resv_start)
-            // Region2 = [resv_end,end)
-            *size_ptr = (size_t)(resv_start - start);
-            *split_start_ptr = resv_end;
-            *split_size_ptr = (size_t)(end - *split_start_ptr);
-            return true;
-        }
-        else {
-            // Trim from above
-            end = resv_start;
-            *size_ptr = (size_t)(end - start);
-            return false;
-        }
+        
+        // Trim from below
+        *start_ptr = resv_end;
+        *size_ptr = (size_t)(end - resv_end);
+        return false;
     }
 
-    // Should be unreachable
+    // Split into two or trim from above
+    if (resv_end < end) {
+        // Split into two
+        // Region1 = [start,resv_start)
+        // Region2 = [resv_end,end)
+        *size_ptr = (size_t)(resv_start - start);
+        *split_start_ptr = resv_end;
+        *split_size_ptr = (size_t)(end - *split_start_ptr);
+        return true;
+    }
+
+    // Trim from above
+    end = resv_start;
+    *size_ptr = (size_t)(end - start);
+    return false;
 }
 
 // Try to free this region (return the number of bytes successfully freed)
@@ -82,15 +77,11 @@ try_boot_free_region(struct fdt* fdt, void* start, size_t size)
             // Entirely before the kernel
             return (size_t)0;
         }
-        else {
-            // Need to trim before
-            size = (size_t)((start + size) - (void*)__kernel_end);
-            start = (void*)__kernel_end;
-        }
+        // Need to trim before
+        size = (size_t)((start + size) - (void*)__kernel_end);
+        start = (void*)__kernel_end;
     }
-    else {
-        // No addresses lower than the end of the kernel (so no overlap)
-    }
+    // No addresses lower than the end of the kernel (so no overlap)
 
     // Handle the reserve entries in the FDT
     struct fdt_reserve_entry* entry = fdt_reserve_entry_begin(fdt);
@@ -105,15 +96,11 @@ try_boot_free_region(struct fdt* fdt, void* start, size_t size)
             return try_boot_free_region(fdt, start, size)
                    + try_boot_free_region(fdt, split_start, split_size);
         }
-        else {
-            if (size == 0) {
-                // We got fully trimmed
-                return (size_t)0;
-            }
-            else {
-                // We're still one contiguous region (continue)
-            }
+        if (size == 0) {
+            // We got fully trimmed
+            return (size_t)0;
         }
+        // We're still one contiguous region (continue)
 
         entry = fdt_next_reserve_entry(fdt, entry);
     }
@@ -129,15 +116,12 @@ try_boot_free_region(struct fdt* fdt, void* start, size_t size)
         return try_boot_free_region(fdt, start, size)
                + try_boot_free_region(fdt, split_start, split_size);
     }
-    else {
-        if (size == 0) {
-            // We got fully trimmed
-            return (size_t)0;
-        }
-        else {
-            // We're still one contiguous region (continue)
-        }
+
+    if (size == 0) {
+        // We got fully trimmed
+        return (size_t)0;
     }
+    // We're still one contiguous region (continue)
 
     // We made it through (possibly shrunk)
     if (boot_free(start, size) != KERR_SUCCESS) {

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -65,7 +65,7 @@ trim_or_split_around_reserved(
 static size_t
 try_boot_free_region(struct fdt* fdt, void* start, size_t size)
 {
-    // Should be unnecessary (but it's worth checking incase someone messes up)
+    // Should be unnecessary (but it's worth checking in case someone messes up)
     if (size == 0) {
         return (size_t)0;
     }

--- a/kernel/of/fdt_mem.c
+++ b/kernel/of/fdt_mem.c
@@ -1,6 +1,62 @@
 
 #include <kernel/of/fdt_mem.h>
 
+// Try to free this region (return the number of bytes successfully freed)
+static size_t
+try_boot_free_region(struct fdt* fdt, void* start, size_t size)
+{
+    void* end = start + size;
+
+    // See if we overlap any of the reserve_entries
+    struct fdt_reserve_entry* entry = fdt_reserve_entry_begin(fdt);
+    while (entry != NULL) {
+        void* resv_start = fdt_reserve_entry_address(entry);
+        size_t resv_size = fdt_reserve_entry_size(entry);
+
+        void* resv_end = resv_start + resv_size;
+
+        if (resv_end <= start || resv_start > end) {
+            // No overlap with this reserve entry
+        }
+        else if (resv_start <= start) {
+            // Fully covering or trim from below
+            if (resv_end >= end) {
+                // Fully covering (this region is entirely reserved)
+                return (size_t)0;
+            }
+            else {
+                // Trim from below
+                start = resv_end;
+                size = (size_t)(end - resv_end);
+            }
+        }
+        else {
+            // Split into two or trim from above
+            if (resv_end < end) {
+                // Split into two
+                // Region1 = [start,resv_start)
+                // Region2 = [resv_end,end)
+                return try_boot_free_region(fdt, start, (size_t)(resv_start - start))
+                       + try_boot_free_region(fdt, resv_end, (size_t)(end - resv_end));
+            }
+            else {
+                // Trim from above
+                end = resv_start;
+                size = (size_t)(end - start);
+            }
+        }
+
+        entry = fdt_next_reserve_entry(fdt, entry);
+    }
+
+    // We made it through (possibly shrunk)
+    if (boot_free(start, size) != KERR_SUCCESS) {
+        // We couldn't free for some reason
+        return (size_t)0;
+    }
+    return size;
+}
+
 /*
  * Use the FDT to hand off free memory regions to the "boot" memory allocator
  */
@@ -9,6 +65,8 @@ fdt_boot_mem_init(struct fdt* fdt)
 {
     struct fdt_node* mem_node = fdt_find_node_by_device_type(fdt, NULL, "memory");
     while (mem_node != NULL) {
+        // TODO: Actually free memory
         mem_node = fdt_find_node_by_device_type(fdt, mem_node, "memory");
     }
+    return KERR_SUCCESS;
 }

--- a/libc/src/stdio/printf.c
+++ b/libc/src/stdio/printf.c
@@ -2,8 +2,8 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define POINTERS_USE_CAPTIAL_HEX true
 

--- a/libc/src/stdio/printf.c
+++ b/libc/src/stdio/printf.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define POINTERS_USE_CAPTIAL_HEX true
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,4 +9,5 @@ qemu-system-riscv64 \
     -bios none \
     -kernel "$PWD/../build/riscy-os.elf" \
     -serial mon:stdio \
+    -m 1G \
     "$@"


### PR DESCRIPTION
Adds a "boot memory allocator" framework, and implements a simple SLAB based memory allocator for use before we can set up a buddy allocator for regular page sized allocations.

Adds new features to the FDT library making reading common properties and getting inherited property info much easier.

Detects the bounds of memory using the FDT and protects reserved regions of memory like the kernel, firmware, and FDT from boot memory allocations.