### PR TITLE
"syscon fix" 

### DIFF
--- a/arch/riscv/kernel.c
+++ b/arch/riscv/kernel.c
@@ -1,7 +1,7 @@
 #include "kernel/early_output.h"
+#include "kernel/mem/boot.h"
 #include "kernel/of/fdt.h"
 #include "kernel/of/fdt_mem.h"
-#include "kernel/mem/boot.h"
 
 #include "drivers/syscon.h"
 
@@ -131,7 +131,7 @@ kmain(uint64_t hartid, struct fdt* fdt)
         printk("Error setting up syscon\n");
         syscon_ok = false;
     }
-    
+
     // Call global ctors
     preinit();
     init();

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -9,64 +9,248 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static volatile uint32_t* SYSCON_ADDR = 0; /* NOLINT */
-
-#define SYSCON_SHUTDOWN 0x5555
-#define SYSCON_REBOOT   0x7777
+static bool shutdown_found = false;
+static volatile uint32_t *shutdown_register;
+static uint32_t shutdown_mask;
+static uint32_t shutdown_value;
 
 kerror_t
-syscon_init(struct fdt* fdt)
+syscon_shutdown_init(struct fdt* fdt)
 {
-    /* Get our syscon FDT node */
-    struct fdt_node* syscon = fdt_find_compatible_node(fdt, NULL, "syscon");
-    if (!syscon)
-        return KERR_NO_EXIST;
+    shutdown_found = false;
 
-    printk("Found syscon (%s)\n", fdt_node_name(syscon));
+    // See if we have a generic "syscon-poweroff" node
+    struct fdt_node *shutdown_node = fdt_find_compatible_node(fdt, NULL, "syscon-poweroff");
+    if(shutdown_node == NULL) {
+      return KERR_NO_EXIST;
+    }
 
-    /* Get the reg property */
-    struct fdt_prop* syscon_reg = fdt_get_prop_by_name(fdt, syscon, NULL, "reg");
-    if (!syscon_reg)
-        return KERR_NO_EXIST;
+    // Get the phandle to the syscon this poweroff node is referring to
+    struct fdt_prop *regmap = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"regmap");
+    if(regmap == NULL) {
+      return KERR_NO_EXIST;
+    }
 
-    /* Should be 4 x 32 bit values */
-    uint32_t len = be32toh(syscon_reg->len);
-    assert(len == 4 * sizeof(uint32_t));
+    size_t regmap_cells = fdt_prop_num_cells(regmap);
+    if(regmap_cells != 1) {
+      return KERR_NO_EXIST;
+    }
+    uint32_t syscon_phandle = fdt_prop_get_cell(regmap,0);
 
-    /* The second one is the syscon address */
-    uint32_t* values = (uint32_t*)(syscon_reg->val); /* NOLINT */
+    // Use the phandle to get the syscon node
+    struct fdt_node * syscon = fdt_find_node_by_phandle(fdt,NULL,syscon_phandle);
+    if(syscon == NULL) {
+      return KERR_NO_EXIST;
+    }
+  
+    // Make sure the syscon has atleast 1 register block
+    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt,syscon);
+    if(syscon_reg_block_count < 1) {
+      return KERR_NO_EXIST;
+    }
 
-    uint32_t raw_syscon_addr = be32toh(values[1]);
-    assert(raw_syscon_addr != NULL);
+    // Get the address and size of the syscon register block
+    void *syscon_address;
+    size_t syscon_size;
+    fdt_node_get_register_block(fdt,syscon,0,&syscon_address,&syscon_size);
+    
+    if(syscon_size == 0) {
+      // Error reading register block (or it's actually just zero sized)
+      // (Both would be bad)
+      return KERR_NO_EXIST;
+    }
 
-    /* Set the syscon address */
-    assert(SYSCON_ADDR == NULL); /* should only ever be called once */
-    SYSCON_ADDR = (volatile uint32_t*)raw_syscon_addr; /* NOLINT */
+    // Get the offset into the register block of our 32-bit register
+    struct fdt_prop * offset_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"offset");
+    if(offset_prop == NULL) {
+      return KERR_NO_EXIST;
+    }
 
+    size_t offset_cells = fdt_prop_num_cells(offset_prop);
+    if(offset_cells != 1) {
+      return KERR_NO_EXIST;
+    }
+    uint32_t offset = fdt_prop_get_cell(offset_prop,0);
+
+    // We care about the register at "offset" bytes into the syscon
+    shutdown_register = (uint32_t*)(syscon_address + offset);
+    
+    // Try to get the 32-bit mask we need to use when writing
+    bool found_mask = false;
+
+    struct fdt_prop * mask_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"mask");
+    if(mask_prop != NULL) {
+      size_t mask_cells = fdt_prop_num_cells(mask_prop);
+      if(mask_cells == 1) {
+        found_mask = true;
+        shutdown_mask = fdt_prop_get_cell(mask_prop,0);
+      }
+    } 
+
+    if(!found_mask) {
+      // All one's (effectively no mask)
+      shutdown_mask = (uint32_t)(-1);
+    }
+
+    // Try to get the 32-bit value we actually write
+    bool found_value = false;
+
+    struct fdt_prop * value_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"value");
+    if(value_prop != NULL) {
+      size_t value_cells = fdt_prop_num_cells(value_prop);
+      if(value_cells == 1) {
+        found_value = true;
+        shutdown_value = fdt_prop_get_cell(value_prop,0);
+      }
+    } 
+
+    if(!found_mask && !found_value) {
+      // We didn't find either (something is wrong)
+      return KERR_NO_EXIST;
+    }
+    else if(!found_value) {
+      // We found the mask but didn't find the value
+      // (Use the mask as the value)
+      shutdown_value = shutdown_mask;
+    }
+
+    // We found everything we needed to (enable the shutdown function)
+    shutdown_found = true;
     return KERR_NONE;
 }
 
-volatile uint32_t*
-syscon_mmio_register()
+static bool reboot_found = false;
+static volatile uint32_t *reboot_register;
+static uint32_t reboot_mask;
+static uint32_t reboot_value;
+
+// TODO: This function is a near exact clone of "syscon_shutdown_init"
+//       We can probably make one new function which both 
+//       shutdown_init and reboot_init call with different parameters.
+
+kerror_t
+syscon_reboot_init(struct fdt* fdt)
 {
-    assert(SYSCON_ADDR);
-    return SYSCON_ADDR;
+    reboot_found = false;
+
+    // See if we have a generic "syscon-poweroff" node
+    struct fdt_node *reboot_node = fdt_find_compatible_node(fdt, NULL, "syscon-reboot");
+    if(reboot_node == NULL) {
+      return KERR_NO_EXIST;
+    }
+
+    // Get the phandle to the syscon this poweroff node is referring to
+    struct fdt_prop *regmap = fdt_get_prop_by_name(fdt,reboot_node,NULL,"regmap");
+    if(regmap == NULL) {
+      return KERR_NO_EXIST;
+    }
+
+    size_t regmap_cells = fdt_prop_num_cells(regmap);
+    if(regmap_cells != 1) {
+      return KERR_NO_EXIST;
+    }
+    uint32_t syscon_phandle = fdt_prop_get_cell(regmap,0);
+
+    // Use the phandle to get the syscon node
+    struct fdt_node * syscon = fdt_find_node_by_phandle(fdt,NULL,syscon_phandle);
+    if(syscon == NULL) {
+      return KERR_NO_EXIST;
+    }
+  
+    // Make sure the syscon has atleast 1 register block
+    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt,syscon);
+    if(syscon_reg_block_count < 1) {
+      return KERR_NO_EXIST;
+    }
+
+    // Get the address and size of the syscon register block
+    void *syscon_address;
+    size_t syscon_size;
+    fdt_node_get_register_block(fdt,syscon,0,&syscon_address,&syscon_size);
+    
+    if(syscon_size == 0) {
+      // Error reading register block (or it's actually just zero sized)
+      // (Both would be bad)
+      return KERR_NO_EXIST;
+    }
+
+    // Get the offset into the register block of our 32-bit register
+    struct fdt_prop * offset_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"offset");
+    if(offset_prop == NULL) {
+      return KERR_NO_EXIST;
+    }
+
+    size_t offset_cells = fdt_prop_num_cells(offset_prop);
+    if(offset_cells != 1) {
+      return KERR_NO_EXIST;
+    }
+    uint32_t offset = fdt_prop_get_cell(offset_prop,0);
+
+    // We care about the register at "offset" bytes into the syscon
+    reboot_register = (uint32_t*)(syscon_address + offset);
+    
+    // Try to get the 32-bit mask we need to use when writing
+    bool found_mask = false;
+
+    struct fdt_prop * mask_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"mask");
+    if(mask_prop != NULL) {
+      size_t mask_cells = fdt_prop_num_cells(mask_prop);
+      if(mask_cells == 1) {
+        found_mask = true;
+        reboot_mask = fdt_prop_get_cell(mask_prop,0);
+      }
+    } 
+
+    if(!found_mask) {
+      // All one's (effectively no mask)
+      reboot_mask = (uint32_t)(-1);
+    }
+
+    // Try to get the 32-bit value we actually write
+    bool found_value = false;
+
+    struct fdt_prop * value_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"value");
+    if(value_prop != NULL) {
+      size_t value_cells = fdt_prop_num_cells(value_prop);
+      if(value_cells == 1) {
+        found_value = true;
+        reboot_value = fdt_prop_get_cell(value_prop,0);
+      }
+    } 
+
+    if(!found_mask && !found_value) {
+      // We didn't find either (something is wrong)
+      return KERR_NO_EXIST;
+    }
+    else if(!found_value) {
+      // We found the mask but didn't find the value
+      // (Use the mask as the value)
+      reboot_value = reboot_mask;
+    }
+
+    // We found everything we needed to (enable the reboot function)
+    reboot_found = true;
+    return KERR_NONE;
 }
 
-[[noreturn]] void
+[[noreturn]]
 syscon_shutdown()
 {
-    assert(SYSCON_ADDR);
+    assert(shutdown_found);
 
-    *SYSCON_ADDR = SYSCON_SHUTDOWN;
+    uint32_t curr_val = *shutdown_register;
+    *shutdown_register = (curr_val & ~shutdown_mask) | (shutdown_value & shutdown_mask);
+
     unreachable();
 }
 
 [[noreturn]] void
 syscon_reboot()
 {
-    assert(SYSCON_ADDR);
+    assert(reboot_found);
 
-    *SYSCON_ADDR = SYSCON_REBOOT;
+    uint32_t curr_val = *reboot_register;
+    *reboot_register = (curr_val & ~reboot_mask) | (reboot_value & reboot_mask);
+
     unreachable();
 }

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 
 static bool shutdown_found = false;
-static volatile uint32_t *shutdown_register;
+static volatile uint32_t* shutdown_register;
 static uint32_t shutdown_mask;
 static uint32_t shutdown_value;
 
@@ -20,98 +20,101 @@ syscon_shutdown_init(struct fdt* fdt)
     shutdown_found = false;
 
     // See if we have a generic "syscon-poweroff" node
-    struct fdt_node *shutdown_node = fdt_find_compatible_node(fdt, NULL, "syscon-poweroff");
-    if(shutdown_node == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_node* shutdown_node =
+        fdt_find_compatible_node(fdt, NULL, "syscon-poweroff");
+    if (shutdown_node == NULL) {
+        return KERR_NO_EXIST;
     }
 
     // Get the phandle to the syscon this poweroff node is referring to
-    struct fdt_prop *regmap = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"regmap");
-    if(regmap == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_prop* regmap = fdt_get_prop_by_name(fdt, shutdown_node, NULL, "regmap");
+    if (regmap == NULL) {
+        return KERR_NO_EXIST;
     }
 
     size_t regmap_cells = fdt_prop_num_cells(regmap);
-    if(regmap_cells != 1) {
-      return KERR_NO_EXIST;
+    if (regmap_cells != 1) {
+        return KERR_NO_EXIST;
     }
-    uint32_t syscon_phandle = fdt_prop_get_cell(regmap,0);
+    uint32_t syscon_phandle = fdt_prop_get_cell(regmap, 0);
 
     // Use the phandle to get the syscon node
-    struct fdt_node * syscon = fdt_find_node_by_phandle(fdt,NULL,syscon_phandle);
-    if(syscon == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_node* syscon = fdt_find_node_by_phandle(fdt, NULL, syscon_phandle);
+    if (syscon == NULL) {
+        return KERR_NO_EXIST;
     }
-  
-    // Make sure the syscon has atleast 1 register block
-    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt,syscon);
-    if(syscon_reg_block_count < 1) {
-      return KERR_NO_EXIST;
+
+    // Make sure the syscon has at least 1 register block
+    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt, syscon);
+    if (syscon_reg_block_count < 1) {
+        return KERR_NO_EXIST;
     }
 
     // Get the address and size of the syscon register block
-    void *syscon_address;
+    void* syscon_address;
     size_t syscon_size;
-    fdt_node_get_register_block(fdt,syscon,0,&syscon_address,&syscon_size);
-    
-    if(syscon_size == 0) {
-      // Error reading register block (or it's actually just zero sized)
-      // (Both would be bad)
-      return KERR_NO_EXIST;
+    fdt_node_get_register_block(fdt, syscon, 0, &syscon_address, &syscon_size);
+
+    if (syscon_size == 0) {
+        // Error reading register block (or it's actually just zero sized)
+        // (Both would be bad)
+        return KERR_NO_EXIST;
     }
 
     // Get the offset into the register block of our 32-bit register
-    struct fdt_prop * offset_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"offset");
-    if(offset_prop == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_prop* offset_prop =
+        fdt_get_prop_by_name(fdt, shutdown_node, NULL, "offset");
+    if (offset_prop == NULL) {
+        return KERR_NO_EXIST;
     }
 
     size_t offset_cells = fdt_prop_num_cells(offset_prop);
-    if(offset_cells != 1) {
-      return KERR_NO_EXIST;
+    if (offset_cells != 1) {
+        return KERR_NO_EXIST;
     }
-    uint32_t offset = fdt_prop_get_cell(offset_prop,0);
+    uint32_t offset = fdt_prop_get_cell(offset_prop, 0);
 
     // We care about the register at "offset" bytes into the syscon
     shutdown_register = (uint32_t*)(syscon_address + offset);
-    
+
     // Try to get the 32-bit mask we need to use when writing
     bool found_mask = false;
 
-    struct fdt_prop * mask_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"mask");
-    if(mask_prop != NULL) {
-      size_t mask_cells = fdt_prop_num_cells(mask_prop);
-      if(mask_cells == 1) {
-        found_mask = true;
-        shutdown_mask = fdt_prop_get_cell(mask_prop,0);
-      }
-    } 
+    struct fdt_prop* mask_prop = fdt_get_prop_by_name(fdt, shutdown_node, NULL, "mask");
+    if (mask_prop != NULL) {
+        size_t mask_cells = fdt_prop_num_cells(mask_prop);
+        if (mask_cells == 1) {
+            found_mask = true;
+            shutdown_mask = fdt_prop_get_cell(mask_prop, 0);
+        }
+    }
 
-    if(!found_mask) {
-      // All one's (effectively no mask)
-      shutdown_mask = (uint32_t)(-1);
+    if (!found_mask) {
+        // All one's (effectively no mask)
+        shutdown_mask = (uint32_t)(-1);
     }
 
     // Try to get the 32-bit value we actually write
     bool found_value = false;
 
-    struct fdt_prop * value_prop = fdt_get_prop_by_name(fdt,shutdown_node,NULL,"value");
-    if(value_prop != NULL) {
-      size_t value_cells = fdt_prop_num_cells(value_prop);
-      if(value_cells == 1) {
-        found_value = true;
-        shutdown_value = fdt_prop_get_cell(value_prop,0);
-      }
-    } 
-
-    if(!found_mask && !found_value) {
-      // We didn't find either (something is wrong)
-      return KERR_NO_EXIST;
+    struct fdt_prop* value_prop =
+        fdt_get_prop_by_name(fdt, shutdown_node, NULL, "value");
+    if (value_prop != NULL) {
+        size_t value_cells = fdt_prop_num_cells(value_prop);
+        if (value_cells == 1) {
+            found_value = true;
+            shutdown_value = fdt_prop_get_cell(value_prop, 0);
+        }
     }
-    else if(!found_value) {
-      // We found the mask but didn't find the value
-      // (Use the mask as the value)
-      shutdown_value = shutdown_mask;
+
+    if (!found_mask && !found_value) {
+        // We didn't find either (something is wrong)
+        return KERR_NO_EXIST;
+    }
+    else if (!found_value) {
+        // We found the mask but didn't find the value
+        // (Use the mask as the value)
+        shutdown_value = shutdown_mask;
     }
 
     // We found everything we needed to (enable the shutdown function)
@@ -120,12 +123,12 @@ syscon_shutdown_init(struct fdt* fdt)
 }
 
 static bool reboot_found = false;
-static volatile uint32_t *reboot_register;
+static volatile uint32_t* reboot_register;
 static uint32_t reboot_mask;
 static uint32_t reboot_value;
 
 // TODO: This function is a near exact clone of "syscon_shutdown_init"
-//       We can probably make one new function which both 
+//       We can probably make one new function which both
 //       shutdown_init and reboot_init call with different parameters.
 
 kerror_t
@@ -134,98 +137,99 @@ syscon_reboot_init(struct fdt* fdt)
     reboot_found = false;
 
     // See if we have a generic "syscon-poweroff" node
-    struct fdt_node *reboot_node = fdt_find_compatible_node(fdt, NULL, "syscon-reboot");
-    if(reboot_node == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_node* reboot_node = fdt_find_compatible_node(fdt, NULL, "syscon-reboot");
+    if (reboot_node == NULL) {
+        return KERR_NO_EXIST;
     }
 
     // Get the phandle to the syscon this poweroff node is referring to
-    struct fdt_prop *regmap = fdt_get_prop_by_name(fdt,reboot_node,NULL,"regmap");
-    if(regmap == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_prop* regmap = fdt_get_prop_by_name(fdt, reboot_node, NULL, "regmap");
+    if (regmap == NULL) {
+        return KERR_NO_EXIST;
     }
 
     size_t regmap_cells = fdt_prop_num_cells(regmap);
-    if(regmap_cells != 1) {
-      return KERR_NO_EXIST;
+    if (regmap_cells != 1) {
+        return KERR_NO_EXIST;
     }
-    uint32_t syscon_phandle = fdt_prop_get_cell(regmap,0);
+    uint32_t syscon_phandle = fdt_prop_get_cell(regmap, 0);
 
     // Use the phandle to get the syscon node
-    struct fdt_node * syscon = fdt_find_node_by_phandle(fdt,NULL,syscon_phandle);
-    if(syscon == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_node* syscon = fdt_find_node_by_phandle(fdt, NULL, syscon_phandle);
+    if (syscon == NULL) {
+        return KERR_NO_EXIST;
     }
-  
-    // Make sure the syscon has atleast 1 register block
-    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt,syscon);
-    if(syscon_reg_block_count < 1) {
-      return KERR_NO_EXIST;
+
+    // Make sure the syscon has at least 1 register block
+    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt, syscon);
+    if (syscon_reg_block_count < 1) {
+        return KERR_NO_EXIST;
     }
 
     // Get the address and size of the syscon register block
-    void *syscon_address;
+    void* syscon_address;
     size_t syscon_size;
-    fdt_node_get_register_block(fdt,syscon,0,&syscon_address,&syscon_size);
-    
-    if(syscon_size == 0) {
-      // Error reading register block (or it's actually just zero sized)
-      // (Both would be bad)
-      return KERR_NO_EXIST;
+    fdt_node_get_register_block(fdt, syscon, 0, &syscon_address, &syscon_size);
+
+    if (syscon_size == 0) {
+        // Error reading register block (or it's actually just zero sized)
+        // (Both would be bad)
+        return KERR_NO_EXIST;
     }
 
     // Get the offset into the register block of our 32-bit register
-    struct fdt_prop * offset_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"offset");
-    if(offset_prop == NULL) {
-      return KERR_NO_EXIST;
+    struct fdt_prop* offset_prop =
+        fdt_get_prop_by_name(fdt, reboot_node, NULL, "offset");
+    if (offset_prop == NULL) {
+        return KERR_NO_EXIST;
     }
 
     size_t offset_cells = fdt_prop_num_cells(offset_prop);
-    if(offset_cells != 1) {
-      return KERR_NO_EXIST;
+    if (offset_cells != 1) {
+        return KERR_NO_EXIST;
     }
-    uint32_t offset = fdt_prop_get_cell(offset_prop,0);
+    uint32_t offset = fdt_prop_get_cell(offset_prop, 0);
 
     // We care about the register at "offset" bytes into the syscon
     reboot_register = (uint32_t*)(syscon_address + offset);
-    
+
     // Try to get the 32-bit mask we need to use when writing
     bool found_mask = false;
 
-    struct fdt_prop * mask_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"mask");
-    if(mask_prop != NULL) {
-      size_t mask_cells = fdt_prop_num_cells(mask_prop);
-      if(mask_cells == 1) {
-        found_mask = true;
-        reboot_mask = fdt_prop_get_cell(mask_prop,0);
-      }
-    } 
+    struct fdt_prop* mask_prop = fdt_get_prop_by_name(fdt, reboot_node, NULL, "mask");
+    if (mask_prop != NULL) {
+        size_t mask_cells = fdt_prop_num_cells(mask_prop);
+        if (mask_cells == 1) {
+            found_mask = true;
+            reboot_mask = fdt_prop_get_cell(mask_prop, 0);
+        }
+    }
 
-    if(!found_mask) {
-      // All one's (effectively no mask)
-      reboot_mask = (uint32_t)(-1);
+    if (!found_mask) {
+        // All one's (effectively no mask)
+        reboot_mask = (uint32_t)(-1);
     }
 
     // Try to get the 32-bit value we actually write
     bool found_value = false;
 
-    struct fdt_prop * value_prop = fdt_get_prop_by_name(fdt,reboot_node,NULL,"value");
-    if(value_prop != NULL) {
-      size_t value_cells = fdt_prop_num_cells(value_prop);
-      if(value_cells == 1) {
-        found_value = true;
-        reboot_value = fdt_prop_get_cell(value_prop,0);
-      }
-    } 
-
-    if(!found_mask && !found_value) {
-      // We didn't find either (something is wrong)
-      return KERR_NO_EXIST;
+    struct fdt_prop* value_prop = fdt_get_prop_by_name(fdt, reboot_node, NULL, "value");
+    if (value_prop != NULL) {
+        size_t value_cells = fdt_prop_num_cells(value_prop);
+        if (value_cells == 1) {
+            found_value = true;
+            reboot_value = fdt_prop_get_cell(value_prop, 0);
+        }
     }
-    else if(!found_value) {
-      // We found the mask but didn't find the value
-      // (Use the mask as the value)
-      reboot_value = reboot_mask;
+
+    if (!found_mask && !found_value) {
+        // We didn't find either (something is wrong)
+        return KERR_NO_EXIST;
+    }
+    else if (!found_value) {
+        // We found the mask but didn't find the value
+        // (Use the mask as the value)
+        reboot_value = reboot_mask;
     }
 
     // We found everything we needed to (enable the reboot function)
@@ -233,8 +237,7 @@ syscon_reboot_init(struct fdt* fdt)
     return KERR_NONE;
 }
 
-[[noreturn]]
-syscon_shutdown()
+[[noreturn]] syscon_shutdown()
 {
     assert(shutdown_found);
 

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -9,251 +9,165 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static bool shutdown_found = false;
-static volatile uint32_t* shutdown_register;
-static uint32_t shutdown_mask;
-static uint32_t shutdown_value;
+struct generic_syscon_action {
+    bool found;
+    volatile uint32_t* reg;
+    uint32_t mask;
+    uint32_t value;
+};
+
+static struct generic_syscon_action shutdown_action = {
+    .found = false,
+    .reg = NULL,
+    .mask = NULL,
+    .value = NULL,
+};
+
+static struct generic_syscon_action reboot_action = {
+    .found = false,
+    .reg = NULL,
+    .mask = NULL,
+    .value = NULL,
+};
+
+static kerror_t
+syscon_init_generic_action(
+    struct generic_syscon_action* action, void* fdt, const char* compat
+)
+{
+    action->found = false;
+
+    // See if we have a generic "syscon-poweroff" node
+    struct fdt_node* node = fdt_find_compatible_node(fdt, NULL, compat);
+    if (node == NULL) {
+        return KERR_NO_EXIST;
+    }
+
+    // Get the phandle to the syscon this poweroff node is referring to
+    struct fdt_prop* regmap = fdt_get_prop_by_name(fdt, node, NULL, "regmap");
+    if (regmap == NULL) {
+        return KERR_NO_EXIST;
+    }
+
+    size_t regmap_cells = fdt_prop_num_cells(regmap);
+    if (regmap_cells != 1) {
+        return KERR_NO_EXIST;
+    }
+    uint32_t syscon_phandle = fdt_prop_get_cell(regmap, 0);
+
+    // Use the phandle to get the syscon node
+    struct fdt_node* syscon = fdt_find_node_by_phandle(fdt, NULL, syscon_phandle);
+    if (syscon == NULL) {
+        return KERR_NO_EXIST;
+    }
+
+    // Make sure the syscon has at least 1 register block
+    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt, syscon);
+    if (syscon_reg_block_count < 1) {
+        return KERR_NO_EXIST;
+    }
+
+    // Get the address and size of the syscon register block
+    void* syscon_address;
+    size_t syscon_size;
+    fdt_node_get_register_block(fdt, syscon, 0, &syscon_address, &syscon_size);
+
+    if (syscon_size == 0) {
+        // Error reading register block (or it's actually just zero sized)
+        // (Both would be bad)
+        return KERR_NO_EXIST;
+    }
+
+    // Get the offset into the register block of our 32-bit register
+    struct fdt_prop* offset_prop = fdt_get_prop_by_name(fdt, node, NULL, "offset");
+    if (offset_prop == NULL) {
+        return KERR_NO_EXIST;
+    }
+
+    size_t offset_cells = fdt_prop_num_cells(offset_prop);
+    if (offset_cells != 1) {
+        return KERR_NO_EXIST;
+    }
+    uint32_t offset = fdt_prop_get_cell(offset_prop, 0);
+
+    // We care about the register at "offset" bytes into the syscon
+    action->reg = (uint32_t*)(syscon_address + offset);
+
+    // Try to get the 32-bit mask we need to use when writing
+    bool found_mask = false;
+
+    struct fdt_prop* mask_prop = fdt_get_prop_by_name(fdt, node, NULL, "mask");
+    if (mask_prop != NULL) {
+        size_t mask_cells = fdt_prop_num_cells(mask_prop);
+        if (mask_cells == 1) {
+            found_mask = true;
+            action->mask = fdt_prop_get_cell(mask_prop, 0);
+        }
+    }
+
+    if (!found_mask) {
+        // All one's (effectively no mask)
+        action->mask = (uint32_t)(-1);
+    }
+
+    // Try to get the 32-bit value we actually write
+    bool found_value = false;
+
+    struct fdt_prop* value_prop = fdt_get_prop_by_name(fdt, node, NULL, "value");
+    if (value_prop != NULL) {
+        size_t value_cells = fdt_prop_num_cells(value_prop);
+        if (value_cells == 1) {
+            found_value = true;
+            action->value = fdt_prop_get_cell(value_prop, 0);
+        }
+    }
+
+    if (!found_mask && !found_value) {
+        // We didn't find either (something is wrong)
+        return KERR_NO_EXIST;
+    }
+    else if (!found_value) {
+        // We found the mask but didn't find the value
+        // (Use the mask as the value)
+        action->value = action->mask;
+    }
+
+    // We found everything we needed to (enable the shutdown function)
+    action->found = true;
+    return KERR_NONE;
+}
 
 kerror_t
 syscon_shutdown_init(struct fdt* fdt)
 {
-    shutdown_found = false;
-
-    // See if we have a generic "syscon-poweroff" node
-    struct fdt_node* shutdown_node =
-        fdt_find_compatible_node(fdt, NULL, "syscon-poweroff");
-    if (shutdown_node == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    // Get the phandle to the syscon this poweroff node is referring to
-    struct fdt_prop* regmap = fdt_get_prop_by_name(fdt, shutdown_node, NULL, "regmap");
-    if (regmap == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    size_t regmap_cells = fdt_prop_num_cells(regmap);
-    if (regmap_cells != 1) {
-        return KERR_NO_EXIST;
-    }
-    uint32_t syscon_phandle = fdt_prop_get_cell(regmap, 0);
-
-    // Use the phandle to get the syscon node
-    struct fdt_node* syscon = fdt_find_node_by_phandle(fdt, NULL, syscon_phandle);
-    if (syscon == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    // Make sure the syscon has at least 1 register block
-    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt, syscon);
-    if (syscon_reg_block_count < 1) {
-        return KERR_NO_EXIST;
-    }
-
-    // Get the address and size of the syscon register block
-    void* syscon_address;
-    size_t syscon_size;
-    fdt_node_get_register_block(fdt, syscon, 0, &syscon_address, &syscon_size);
-
-    if (syscon_size == 0) {
-        // Error reading register block (or it's actually just zero sized)
-        // (Both would be bad)
-        return KERR_NO_EXIST;
-    }
-
-    // Get the offset into the register block of our 32-bit register
-    struct fdt_prop* offset_prop =
-        fdt_get_prop_by_name(fdt, shutdown_node, NULL, "offset");
-    if (offset_prop == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    size_t offset_cells = fdt_prop_num_cells(offset_prop);
-    if (offset_cells != 1) {
-        return KERR_NO_EXIST;
-    }
-    uint32_t offset = fdt_prop_get_cell(offset_prop, 0);
-
-    // We care about the register at "offset" bytes into the syscon
-    shutdown_register = (uint32_t*)(syscon_address + offset);
-
-    // Try to get the 32-bit mask we need to use when writing
-    bool found_mask = false;
-
-    struct fdt_prop* mask_prop = fdt_get_prop_by_name(fdt, shutdown_node, NULL, "mask");
-    if (mask_prop != NULL) {
-        size_t mask_cells = fdt_prop_num_cells(mask_prop);
-        if (mask_cells == 1) {
-            found_mask = true;
-            shutdown_mask = fdt_prop_get_cell(mask_prop, 0);
-        }
-    }
-
-    if (!found_mask) {
-        // All one's (effectively no mask)
-        shutdown_mask = (uint32_t)(-1);
-    }
-
-    // Try to get the 32-bit value we actually write
-    bool found_value = false;
-
-    struct fdt_prop* value_prop =
-        fdt_get_prop_by_name(fdt, shutdown_node, NULL, "value");
-    if (value_prop != NULL) {
-        size_t value_cells = fdt_prop_num_cells(value_prop);
-        if (value_cells == 1) {
-            found_value = true;
-            shutdown_value = fdt_prop_get_cell(value_prop, 0);
-        }
-    }
-
-    if (!found_mask && !found_value) {
-        // We didn't find either (something is wrong)
-        return KERR_NO_EXIST;
-    }
-    else if (!found_value) {
-        // We found the mask but didn't find the value
-        // (Use the mask as the value)
-        shutdown_value = shutdown_mask;
-    }
-
-    // We found everything we needed to (enable the shutdown function)
-    shutdown_found = true;
-    return KERR_NONE;
+    return syscon_init_generic_action(&shutdown_action, fdt, "syscon-poweroff");
 }
-
-static bool reboot_found = false;
-static volatile uint32_t* reboot_register;
-static uint32_t reboot_mask;
-static uint32_t reboot_value;
-
-// TODO: This function is a near exact clone of "syscon_shutdown_init"
-//       We can probably make one new function which both
-//       shutdown_init and reboot_init call with different parameters.
 
 kerror_t
 syscon_reboot_init(struct fdt* fdt)
 {
-    reboot_found = false;
-
-    // See if we have a generic "syscon-poweroff" node
-    struct fdt_node* reboot_node = fdt_find_compatible_node(fdt, NULL, "syscon-reboot");
-    if (reboot_node == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    // Get the phandle to the syscon this poweroff node is referring to
-    struct fdt_prop* regmap = fdt_get_prop_by_name(fdt, reboot_node, NULL, "regmap");
-    if (regmap == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    size_t regmap_cells = fdt_prop_num_cells(regmap);
-    if (regmap_cells != 1) {
-        return KERR_NO_EXIST;
-    }
-    uint32_t syscon_phandle = fdt_prop_get_cell(regmap, 0);
-
-    // Use the phandle to get the syscon node
-    struct fdt_node* syscon = fdt_find_node_by_phandle(fdt, NULL, syscon_phandle);
-    if (syscon == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    // Make sure the syscon has at least 1 register block
-    size_t syscon_reg_block_count = fdt_node_num_register_blocks(fdt, syscon);
-    if (syscon_reg_block_count < 1) {
-        return KERR_NO_EXIST;
-    }
-
-    // Get the address and size of the syscon register block
-    void* syscon_address;
-    size_t syscon_size;
-    fdt_node_get_register_block(fdt, syscon, 0, &syscon_address, &syscon_size);
-
-    if (syscon_size == 0) {
-        // Error reading register block (or it's actually just zero sized)
-        // (Both would be bad)
-        return KERR_NO_EXIST;
-    }
-
-    // Get the offset into the register block of our 32-bit register
-    struct fdt_prop* offset_prop =
-        fdt_get_prop_by_name(fdt, reboot_node, NULL, "offset");
-    if (offset_prop == NULL) {
-        return KERR_NO_EXIST;
-    }
-
-    size_t offset_cells = fdt_prop_num_cells(offset_prop);
-    if (offset_cells != 1) {
-        return KERR_NO_EXIST;
-    }
-    uint32_t offset = fdt_prop_get_cell(offset_prop, 0);
-
-    // We care about the register at "offset" bytes into the syscon
-    reboot_register = (uint32_t*)(syscon_address + offset);
-
-    // Try to get the 32-bit mask we need to use when writing
-    bool found_mask = false;
-
-    struct fdt_prop* mask_prop = fdt_get_prop_by_name(fdt, reboot_node, NULL, "mask");
-    if (mask_prop != NULL) {
-        size_t mask_cells = fdt_prop_num_cells(mask_prop);
-        if (mask_cells == 1) {
-            found_mask = true;
-            reboot_mask = fdt_prop_get_cell(mask_prop, 0);
-        }
-    }
-
-    if (!found_mask) {
-        // All one's (effectively no mask)
-        reboot_mask = (uint32_t)(-1);
-    }
-
-    // Try to get the 32-bit value we actually write
-    bool found_value = false;
-
-    struct fdt_prop* value_prop = fdt_get_prop_by_name(fdt, reboot_node, NULL, "value");
-    if (value_prop != NULL) {
-        size_t value_cells = fdt_prop_num_cells(value_prop);
-        if (value_cells == 1) {
-            found_value = true;
-            reboot_value = fdt_prop_get_cell(value_prop, 0);
-        }
-    }
-
-    if (!found_mask && !found_value) {
-        // We didn't find either (something is wrong)
-        return KERR_NO_EXIST;
-    }
-    else if (!found_value) {
-        // We found the mask but didn't find the value
-        // (Use the mask as the value)
-        reboot_value = reboot_mask;
-    }
-
-    // We found everything we needed to (enable the reboot function)
-    reboot_found = true;
-    return KERR_NONE;
+    return syscon_init_generic_action(&reboot_action, fdt, "syscon-reboot");
 }
 
-[[noreturn]] syscon_shutdown()
+[[noreturn]] syscon_shutdown(void)
 {
-    assert(shutdown_found);
+    assert(shutdown_action.found);
 
-    uint32_t curr_val = *shutdown_register;
-    *shutdown_register = (curr_val & ~shutdown_mask) | (shutdown_value & shutdown_mask);
+    uint32_t curr_val = *shutdown_action.reg;
+    *shutdown_action.reg = (curr_val & ~shutdown_action.mask)
+                           | (shutdown_action.value & shutdown_action.mask);
 
     unreachable();
 }
 
 [[noreturn]] void
-syscon_reboot()
+syscon_reboot(void)
 {
-    assert(reboot_found);
+    assert(reboot_action.found);
 
-    uint32_t curr_val = *reboot_register;
-    *reboot_register = (curr_val & ~reboot_mask) | (reboot_value & reboot_mask);
+    uint32_t curr_val = *reboot_action.reg;
+    *reboot_action.reg =
+        (curr_val & ~reboot_action.mask) | (reboot_action.value & reboot_action.mask);
 
     unreachable();
 }

--- a/include/drivers/syscon.h
+++ b/include/drivers/syscon.h
@@ -26,14 +26,14 @@ extern "C" {
  * Calling this requires "syscon_shutdown_init" has been called and returned
  * KERR_SUCCESS
  */
-[[noreturn]] void syscon_shutdown();
+[[noreturn]] void syscon_shutdown(void);
 
 /**
  * Reboot the system.
  *
  * Calling this requires "syscon_reboot_init" has been called and returned KERR_SUCCESS
  */
-[[noreturn]] void syscon_reboot();
+[[noreturn]] void syscon_reboot(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/drivers/syscon.h
+++ b/include/drivers/syscon.h
@@ -11,24 +11,26 @@ extern "C" {
 #include <stdint.h>
 
 /**
- * Init the syscon system.
+ * Try to find and initialize a generic "syscon-poweroff" node in the Device Tree.
  */
-[[nodiscard]] kerror_t syscon_init(struct fdt* fdt);
+[[nodiscard]] kerror_t syscon_shutdown_init(struct fdt* fdt);
 
 /**
- * Get the syscon register for our board.
- *
- * @returns The memory address of the syscon register.
+ * Try to find and initialize a generic "syscon-reboot" node in the Device Tree.
  */
-volatile uint32_t* syscon_mmio_register();
+[[nodiscard]] kerror_t syscon_reboot_init(struct fdt* fdt);
 
 /**
  * Shutdown the system.
+ *
+ * Calling this requires "syscon_shutdown_init" has been called and returned KERR_SUCCESS
  */
 [[noreturn]] void syscon_shutdown();
 
 /**
  * Reboot the system.
+ *
+ * Calling this requires "syscon_reboot_init" has been called and returned KERR_SUCCESS
  */
 [[noreturn]] void syscon_reboot();
 

--- a/include/drivers/syscon.h
+++ b/include/drivers/syscon.h
@@ -23,7 +23,8 @@ extern "C" {
 /**
  * Shutdown the system.
  *
- * Calling this requires "syscon_shutdown_init" has been called and returned KERR_SUCCESS
+ * Calling this requires "syscon_shutdown_init" has been called and returned
+ * KERR_SUCCESS
  */
 [[noreturn]] void syscon_shutdown();
 

--- a/include/kernel/error.h
+++ b/include/kernel/error.h
@@ -22,6 +22,8 @@ enum kerror {
     KERR_FULL,  // Trying to insert/push into a full data structure
     KERR_EMPTY, // Trying to read/pop from an empty data structure
 
+    KERR_INVALID, // Some data is malformed
+
     KERR_BUSY, // Less so an error, but an opportunity to do other work and try again
                // later
 

--- a/include/kernel/of/fdt.h
+++ b/include/kernel/of/fdt.h
@@ -218,6 +218,14 @@ struct fdt_node*
 fdt_find_node_by_unit_name(struct fdt* fdt, struct fdt_node* start, const char* name);
 
 /*
+ * Find the node referenced by "phandle"
+ * The search will begin on node "start" (exclusive)
+ * or if "start" is NULL, the first node in the FDT (inclusive)
+ */
+struct fdt_node*
+fdt_find_node_by_phandle(struct fdt* fdt, struct fdt_node* start, uint32_t phandle);
+
+/*
  * Returns true if "node" is compatible with "compat", else false
  */
 bool fdt_node_is_compatible(struct fdt* fdt, struct fdt_node* node, const char* compat);

--- a/kernel/mem/boot/free_list.c
+++ b/kernel/mem/boot/free_list.c
@@ -61,7 +61,7 @@ alloc_after(struct boot_free_region* region, size_t size, unsigned int alignment
 {
     uintptr_t end = (uintptr_t)region + region->size;
     // Get how far off from being aligned it is
-    // TODO: (if unalignment > sizeof(struct boot_free_region) 
+    // TODO: (if unalignment > sizeof(struct boot_free_region)
     //        we should split the region in the free list to waste less memory.
     //        This is especially important for page allocations)
     size_t unalignment = (end - size) & ((1ull << alignment) - 1ull);

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -548,6 +548,36 @@ fdt_find_node_by_unit_name(struct fdt* fdt, struct fdt_node* start, const char* 
     return NULL;
 }
 
+struct fdt_node*
+fdt_find_node_by_phandle(struct fdt* fdt, struct fdt_node* start, uint32_t phandle)
+{
+    struct fdt_node* node;
+    if (start != NULL) {
+        node = fdt_next_node(fdt, start, NULL);
+    }
+    else {
+        node = fdt_node_begin(fdt);
+    }
+
+    while (node != NULL) {
+        struct fdt_prop* phandle_prop =
+            fdt_get_prop_by_name(fdt, node, NULL, "phandle");
+        if (phandle_prop) {
+            size_t num_cells = fdt_prop_num_cells(phandle_prop);
+            if (num_cells != 1) {
+                // This is an incorrect "phandle" property
+                continue;
+            }
+            if (phandle == fdt_prop_get_cell(phandle_prop, 0)) {
+                return node;
+            }
+        }
+        node = fdt_next_node(fdt, node, NULL);
+    }
+
+    return NULL;
+}
+
 struct fdt_prop*
 fdt_node_get_inherited_prop(
     struct fdt* fdt, struct fdt_node* node, const char* prop_name

--- a/kernel/of/fdt.c
+++ b/kernel/of/fdt.c
@@ -571,7 +571,7 @@ fdt_find_node_by_phandle(struct fdt* fdt, struct fdt_node* start, uint32_t phand
                 // This is an incorrect "phandle" property
                 continue;
             }
-            if (phandle == fdt_prop_get_cell(phandle_prop, 0)) {
+            if (fdt_prop_get_cell(phandle_prop, 0) == phandle) {
                 return node;
             }
         }


### PR DESCRIPTION
It's not exactly a "fix" it's just if we tried to run on anything other than the exact QEMU setup in run.sh the "syscon" driver would fail.

syscon is just a generic set of registers but we had hardcoded access offsets and values which I'm guessing were just grabbed from OSDev or something? Now we should be able to use the reboot and/or shutdown functionality of syscon registers if they exist regardless of the SoC.